### PR TITLE
feat: add runtime profile diff reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ import {
   buildExecutionResultsReport,
   buildImportLoopProfile,
   buildPlatformProbes,
+  buildProfileDiff,
   buildWorkspacePlan,
   createCaptureApi,
   inspectFixtureSet,
@@ -60,6 +61,7 @@ import {
   renderExecutionResultsMarkdown,
   renderImportLoopProfileMarkdown,
   renderPlatformProbesMarkdown,
+  renderProfileDiffMarkdown,
   renderWorkspacePlanMarkdown,
   renderMarkdownReport,
   writeCiSummary,
@@ -68,6 +70,7 @@ import {
   writeExecutionResultsReport,
   writeImportLoopProfile,
   writePlatformProbes,
+  writeProfileDiff,
   writeWorkspacePlan,
   writeReport,
 } from "@openclaw/plugin-inspector";
@@ -98,6 +101,9 @@ await writeExecutionResultsReport(executionResults);
 
 const importLoop = await buildImportLoopProfile({ entrypoint: "dist/index.js", runs: 3 });
 await writeImportLoopProfile(importLoop);
+
+const profileDiff = await buildProfileDiff({ current, baseline, policy });
+await writeProfileDiff(profileDiff);
 ```
 
 ## Scope

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "./import-loop-profile": "./src/import-loop-profile.js",
     "./openclaw-target": "./src/openclaw-target.js",
     "./platform-probes": "./src/platform-probes.js",
+    "./profile-diff": "./src/profile-diff.js",
     "./workspace-plan": "./src/workspace-plan.js"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,13 @@ export {
   writePlatformProbes,
 } from "./platform-probes.js";
 export {
+  buildProfileDiff,
+  defaultProfileDiffOptions,
+  renderProfileDiffMarkdown,
+  validateProfileDiff,
+  writeProfileDiff,
+} from "./profile-diff.js";
+export {
   renderMarkdownReport,
   renderTextSummary,
   writeReport,

--- a/src/profile-diff.js
+++ b/src/profile-diff.js
@@ -1,0 +1,232 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { renderMarkdownTable, writeJsonMarkdownArtifacts } from "./artifacts.js";
+
+export const defaultProfileDiffOptions = {
+  baselinePath: "baselines/runtime/main.json",
+  generatedAt: "deterministic",
+  jsonPath: "reports/plugin-runtime-profile-diff.json",
+  markdownPath: "reports/plugin-runtime-profile-diff.md",
+  policyPath: "plugin-inspector.policy.json",
+  reportTitle: "Plugin Runtime Profile Diff",
+};
+
+export async function buildProfileDiff(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const policy = options.policy ?? (await readJson(resolveFromRoot(rootDir, options.policyPath ?? defaultProfileDiffOptions.policyPath)));
+  const current = options.current ?? (await readJson(resolveFromRoot(rootDir, options.currentPath)));
+  const baseline =
+    options.baseline ??
+    (await readOptionalJson(resolveFromRoot(rootDir, options.baselinePath ?? defaultProfileDiffOptions.baselinePath)));
+  const checks = baseline ? compareProfiles({ baseline, current, policy, strict: options.strict }) : [];
+
+  if (!baseline) {
+    checks.push({
+      id: "profile.baseline.missing",
+      action: "warn",
+      metric: "baseline",
+      message: "runtime profile baseline is missing",
+      baseline: null,
+      current: null,
+      delta: null,
+    });
+  }
+
+  return {
+    generatedAt: options.generatedAt ?? defaultProfileDiffOptions.generatedAt,
+    status: checks.some((check) => check.action === "fail") ? "fail" : "pass",
+    strict: Boolean(options.strict),
+    baseline: baseline ? profileSummary(baseline) : null,
+    current: profileSummary(current),
+    thresholds: policy.thresholds,
+    summary: {
+      checkCount: checks.length,
+      failCount: checks.filter((check) => check.action === "fail").length,
+      warnCount: checks.filter((check) => check.action === "warn").length,
+      passCount: checks.filter((check) => check.action === "pass").length,
+    },
+    checks,
+  };
+}
+
+export function validateProfileDiff(diff) {
+  return diff.checks
+    .filter((check) => check.action === "fail")
+    .map((check) => `${check.id}: ${check.message}: baseline=${check.baseline}, current=${check.current}`);
+}
+
+export async function writeProfileDiff(diff, options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const jsonPath = resolveFromRoot(rootDir, options.jsonPath ?? defaultProfileDiffOptions.jsonPath);
+  const markdownPath = resolveFromRoot(rootDir, options.markdownPath ?? defaultProfileDiffOptions.markdownPath);
+  return writeJsonMarkdownArtifacts({
+    jsonPath,
+    markdownPath,
+    json: diff,
+    markdown: renderProfileDiffMarkdown(diff, options),
+    check: options.check,
+  });
+}
+
+export function renderProfileDiffMarkdown(diff, options = {}) {
+  const title = options.title ?? options.reportTitle ?? defaultProfileDiffOptions.reportTitle;
+  return [
+    `# ${title}`,
+    "",
+    `Generated: ${diff.generatedAt}`,
+    `Status: ${diff.status.toUpperCase()}`,
+    `Strict: ${diff.strict}`,
+    "",
+    "## Summary",
+    "",
+    markdownTable(
+      [
+        ["Checks", diff.summary.checkCount],
+        ["Fail", diff.summary.failCount],
+        ["Warn", diff.summary.warnCount],
+        ["Pass", diff.summary.passCount],
+        ["Current runs", diff.current.runs],
+        ["Baseline runs", diff.baseline?.runs ?? "-"],
+      ],
+      ["Metric", "Value"],
+    ),
+    "",
+    "## Checks",
+    "",
+    markdownTable(
+      diff.checks.map((check) => [
+        check.action,
+        check.id,
+        check.metric,
+        check.baseline ?? "-",
+        check.current ?? "-",
+        check.delta ?? "-",
+        check.percent === undefined ? "-" : `${check.percent}%`,
+        check.message,
+      ]),
+      ["Action", "ID", "Metric", "Baseline", "Current", "Delta", "Percent", "Message"],
+    ),
+  ].join("\n");
+}
+
+function compareProfiles({ baseline, current, policy, strict }) {
+  const thresholds = policy.thresholds;
+  const strictEligible = current.runs >= thresholds.strictMinimumSamples;
+  return [
+    percentCheck({
+      id: "profile.wall-p95",
+      metric: "p95WallMs",
+      baseline: baseline.summary.p95WallMs,
+      current: current.summary.p95WallMs,
+      threshold: thresholds.wallP95RegressionPercent,
+      strict,
+      strictEligible,
+    }),
+    absoluteCheck({
+      id: "profile.peak-rss",
+      metric: "maxPeakRssMb",
+      baseline: baseline.summary.maxPeakRssMb,
+      current: current.summary.maxPeakRssMb,
+      threshold: thresholds.peakRssRegressionMb,
+      strict,
+      strictEligible,
+    }),
+    absoluteCheck({
+      id: "profile.node-boot",
+      metric: "nodeBootWallMs",
+      baseline: commandWall(baseline, "node-boot"),
+      current: commandWall(current, "node-boot"),
+      threshold: thresholds.bootRegressionMs,
+      strict,
+      strictEligible,
+    }),
+    ...registrySurfaceChecks(baseline, current),
+  ];
+}
+
+function percentCheck({ id, metric, baseline, current, threshold, strict, strictEligible }) {
+  const delta = current - baseline;
+  const percent = baseline > 0 ? Math.round((delta / baseline) * 1000) / 10 : 0;
+  const exceeded = delta > 0 && percent > threshold;
+  return {
+    id,
+    action: exceeded ? (strict && strictEligible ? "fail" : "warn") : "pass",
+    metric,
+    message: exceeded
+      ? `${metric} regressed ${percent}% over baseline`
+      : `${metric} stayed within ${threshold}% regression threshold`,
+    baseline,
+    current,
+    delta,
+    percent,
+  };
+}
+
+function absoluteCheck({ id, metric, baseline, current, threshold, strict, strictEligible }) {
+  const delta = current - baseline;
+  const exceeded = delta > threshold;
+  return {
+    id,
+    action: exceeded ? (strict && strictEligible ? "fail" : "warn") : "pass",
+    metric,
+    message: exceeded
+      ? `${metric} regressed ${delta} over baseline`
+      : `${metric} stayed within ${threshold} absolute regression threshold`,
+    baseline,
+    current,
+    delta,
+  };
+}
+
+function registrySurfaceChecks(baseline, current) {
+  return [
+    "compatRecords",
+    "hookNames",
+    "apiRegistrars",
+    "capturedRegistrars",
+    "sdkExports",
+    "manifestFields",
+    "manifestContractFields",
+  ].map((metric) => ({
+    id: `registry.${metric}`,
+    action: "pass",
+    metric,
+    message: "registry surface delta is tracked as context",
+    baseline: baseline.targetOpenClaw[metric],
+    current: current.targetOpenClaw[metric],
+    delta: current.targetOpenClaw[metric] - baseline.targetOpenClaw[metric],
+  }));
+}
+
+function commandWall(profile, commandId) {
+  return profile.commands.find((command) => command.id === commandId)?.wallMs?.median ?? 0;
+}
+
+function profileSummary(profile) {
+  return {
+    runs: profile.runs,
+    summary: profile.summary,
+    targetOpenClaw: profile.targetOpenClaw,
+    fixtureInventory: profile.fixtureInventory,
+  };
+}
+
+async function readJson(jsonPath) {
+  return JSON.parse(await readFile(jsonPath, "utf8"));
+}
+
+async function readOptionalJson(jsonPath) {
+  return existsSync(jsonPath) ? readJson(jsonPath) : null;
+}
+
+function resolveFromRoot(rootDir, candidatePath) {
+  if (!candidatePath) {
+    throw new Error("profile diff path is required");
+  }
+  return path.isAbsolute(candidatePath) ? candidatePath : path.resolve(rootDir, candidatePath);
+}
+
+function markdownTable(rows, headers) {
+  return renderMarkdownTable(rows, headers, { empty: "_none_", escape: false, padding: true });
+}

--- a/test/profile-diff.test.js
+++ b/test/profile-diff.test.js
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  buildProfileDiff,
+  defaultProfileDiffOptions,
+  renderProfileDiffMarkdown,
+  validateProfileDiff,
+} from "../src/index.js";
+
+const policy = {
+  thresholds: {
+    wallP95RegressionPercent: 50,
+    peakRssRegressionMb: 50,
+    bootRegressionMs: 500,
+    strictMinimumSamples: 3,
+  },
+};
+
+test("profile diff warns on noisy regressions by default", async () => {
+  const diff = await buildProfileDiff({
+    baseline: profile({ p95WallMs: 100, maxPeakRssMb: 100, nodeBootMs: 50, runs: 1 }),
+    current: profile({ p95WallMs: 200, maxPeakRssMb: 180, nodeBootMs: 700, runs: 1 }),
+    policy,
+  });
+
+  assert.equal(diff.generatedAt, defaultProfileDiffOptions.generatedAt);
+  assert.equal(diff.status, "pass");
+  assert.equal(diff.summary.warnCount, 3);
+  assert.deepEqual(validateProfileDiff(diff), []);
+  assert.match(renderProfileDiffMarkdown(diff), /Runtime Profile Diff/);
+});
+
+test("profile diff fails strict regressions after enough samples", async () => {
+  const diff = await buildProfileDiff({
+    baseline: profile({ p95WallMs: 100, maxPeakRssMb: 100, nodeBootMs: 50, runs: 3 }),
+    current: profile({ p95WallMs: 200, maxPeakRssMb: 180, nodeBootMs: 700, runs: 3 }),
+    policy,
+    strict: true,
+  });
+
+  assert.equal(diff.status, "fail");
+  assert.ok(validateProfileDiff(diff).some((error) => error.includes("profile.wall-p95")));
+});
+
+test("profile diff does not fail strict regressions before the sample floor", async () => {
+  const diff = await buildProfileDiff({
+    baseline: profile({ p95WallMs: 100, maxPeakRssMb: 100, nodeBootMs: 50, runs: 3 }),
+    current: profile({ p95WallMs: 200, maxPeakRssMb: 180, nodeBootMs: 700, runs: 2 }),
+    policy,
+    strict: true,
+  });
+
+  assert.equal(diff.status, "pass");
+  assert.equal(diff.summary.warnCount, 3);
+  assert.deepEqual(validateProfileDiff(diff), []);
+});
+
+test("profile diff threshold boundaries are inclusive", async () => {
+  const diff = await buildProfileDiff({
+    baseline: profile({ p95WallMs: 100, maxPeakRssMb: 100, nodeBootMs: 50, runs: 3 }),
+    current: profile({ p95WallMs: 150, maxPeakRssMb: 150, nodeBootMs: 550, runs: 3 }),
+    policy,
+    strict: true,
+  });
+
+  assert.equal(diff.status, "pass");
+  assert.equal(diff.summary.passCount, 10);
+  assert.deepEqual(validateProfileDiff(diff), []);
+});
+
+test("profile diff warns but does not fail when baseline is missing", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-profile-baseline-"));
+  const diff = await buildProfileDiff({
+    baselinePath: path.join(dir, "missing.json"),
+    current: profile({ p95WallMs: 100, maxPeakRssMb: 100, nodeBootMs: 50, runs: 3 }),
+    policy,
+    strict: true,
+  });
+
+  assert.equal(diff.status, "pass");
+  assert.equal(diff.summary.warnCount, 1);
+  assert.equal(diff.checks[0].id, "profile.baseline.missing");
+  assert.deepEqual(validateProfileDiff(diff), []);
+});
+
+function profile({ p95WallMs, maxPeakRssMb, nodeBootMs, runs }) {
+  return {
+    runs,
+    summary: {
+      commandCount: 1,
+      p50WallMs: p95WallMs,
+      p95WallMs,
+      maxPeakRssMb,
+    },
+    targetOpenClaw: {
+      compatRecords: 1,
+      hookNames: 2,
+      apiRegistrars: 3,
+      capturedRegistrars: 4,
+      sdkExports: 5,
+      manifestFields: 6,
+      manifestContractFields: 7,
+    },
+    fixtureInventory: {
+      fixtures: 1,
+      sourceFiles: 1,
+      observedHooks: 1,
+      observedRegistrations: 1,
+      observedSdkImports: 1,
+      contractProbes: 1,
+      issueFindings: 1,
+    },
+    commands: [
+      {
+        id: "node-boot",
+        wallMs: { median: nodeBootMs },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable runtime profile diff report helpers
- expose JSON/Markdown writer and profile regression validation
- document and export the profile-diff subpath

## Verification
- npm test
- npm pack --dry-run