### PR TITLE
feat: add runtime profile reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ import {
   buildImportLoopProfile,
   buildPlatformProbes,
   buildProfileDiff,
+  buildRuntimeProfile,
   buildWorkspacePlan,
   createCaptureApi,
   inspectFixtureSet,
@@ -62,9 +63,11 @@ import {
   renderImportLoopProfileMarkdown,
   renderPlatformProbesMarkdown,
   renderProfileDiffMarkdown,
+  renderRuntimeProfileMarkdown,
   renderWorkspacePlanMarkdown,
   renderMarkdownReport,
   validateContractCoverage,
+  validateRuntimeProfile,
   writeCiSummary,
   writeColdImportReadiness,
   writeContractCapture,
@@ -72,6 +75,7 @@ import {
   writeImportLoopProfile,
   writePlatformProbes,
   writeProfileDiff,
+  writeRuntimeProfile,
   writeWorkspacePlan,
   writeReport,
 } from "@openclaw/plugin-inspector";
@@ -103,6 +107,9 @@ await writeExecutionResultsReport(executionResults);
 
 const importLoop = await buildImportLoopProfile({ entrypoint: "dist/index.js", runs: 3 });
 await writeImportLoopProfile(importLoop);
+
+const runtimeProfile = await buildRuntimeProfile({ report, inspection, runs: 1 });
+await writeRuntimeProfile(runtimeProfile);
 
 const profileDiff = await buildProfileDiff({ current, baseline, policy });
 await writeProfileDiff(profileDiff);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "./openclaw-target": "./src/openclaw-target.js",
     "./platform-probes": "./src/platform-probes.js",
     "./profile-diff": "./src/profile-diff.js",
+    "./runtime-profile": "./src/runtime-profile.js",
     "./workspace-plan": "./src/workspace-plan.js"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,14 @@ export {
   writeReport,
 } from "./report.js";
 export {
+  buildRuntimeProfile,
+  defaultRuntimeProfileCommands,
+  defaultRuntimeProfileOptions,
+  renderRuntimeProfileMarkdown,
+  validateRuntimeProfile,
+  writeRuntimeProfile,
+} from "./runtime-profile.js";
+export {
   buildSyntheticProbePlan,
   defaultSyntheticHookContexts,
   defaultSyntheticHookEvents,

--- a/src/runtime-profile.js
+++ b/src/runtime-profile.js
@@ -1,0 +1,399 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { renderMarkdownTable, writeJsonMarkdownArtifacts } from "./artifacts.js";
+
+export const defaultRuntimeProfileOptions = {
+  generatedAt: "deterministic",
+  jsonPath: "reports/plugin-runtime-profile.json",
+  markdownPath: "reports/plugin-runtime-profile.md",
+  reportTitle: "Plugin Runtime Profile",
+  runs: 1,
+};
+
+export const defaultRuntimeProfileCommands = [
+  {
+    id: "node-boot",
+    label: "Node boot",
+    category: "baseline",
+    args: ["-e", "0"],
+    openclaw: false,
+  },
+];
+
+export async function buildRuntimeProfile(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const generatedAt = options.generatedAt ?? defaultRuntimeProfileOptions.generatedAt;
+  const runs = options.runs ?? defaultRuntimeProfileOptions.runs;
+  const commands = [];
+  assertRuns(runs);
+
+  for (const command of options.commands ?? defaultRuntimeProfileCommands) {
+    const samples = [];
+    for (let index = 0; index < runs; index += 1) {
+      samples.push(await profileCommand(command, { ...options, rootDir }));
+    }
+    commands.push(summarizeCommand(command, samples));
+  }
+
+  return {
+    generatedAt,
+    runs,
+    targetOpenClaw: options.targetOpenClaw ?? summarizeTargetOpenClaw(options.report?.targetOpenClaw),
+    fixtureInventory: options.fixtureInventory ?? summarizeFixtureInventory(options.report, options.inspection),
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      node: process.version,
+      rssSampler: process.platform === "win32" ? "unavailable" : "ps",
+      cpuSampler: process.platform === "win32" ? "unavailable" : "ps-percent",
+    },
+    summary: summarizeProfile(commands),
+    groups: summarizeCommandGroups(commands),
+    commands,
+  };
+}
+
+export function validateRuntimeProfile(profile) {
+  const errors = [];
+  for (const command of profile.commands) {
+    if (command.exitCodes.some((code) => code !== 0)) {
+      errors.push(`${command.id}: nonzero exit code(s): ${command.exitCodes.join(", ")}`);
+    }
+    if (command.wallMs.max <= 0) {
+      errors.push(`${command.id}: missing wall time`);
+    }
+  }
+  if (profile.platform?.rssSampler !== "unavailable" && profile.commands.every((command) => command.peakRssMb.max <= 0)) {
+    errors.push("all commands are missing peak RSS");
+  }
+  return errors;
+}
+
+export async function writeRuntimeProfile(profile, options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const jsonPath = resolveFromRoot(rootDir, options.jsonPath ?? defaultRuntimeProfileOptions.jsonPath);
+  const markdownPath = resolveFromRoot(rootDir, options.markdownPath ?? defaultRuntimeProfileOptions.markdownPath);
+  return writeJsonMarkdownArtifacts({
+    jsonPath,
+    markdownPath,
+    json: profile,
+    markdown: renderRuntimeProfileMarkdown(profile, options),
+    check: options.check,
+  });
+}
+
+export function renderRuntimeProfileMarkdown(profile, options = {}) {
+  const title = options.title ?? options.reportTitle ?? defaultRuntimeProfileOptions.reportTitle;
+  return [
+    `# ${title}`,
+    "",
+    `Generated: ${profile.generatedAt}`,
+    `Samples per command: ${profile.runs}`,
+    "",
+    "## Summary",
+    "",
+    markdownTable(
+      [
+        ["Commands", profile.summary.commandCount],
+        ["P50 wall time", `${profile.summary.p50WallMs} ms`],
+        ["P95 wall time", `${profile.summary.p95WallMs} ms`],
+        ["Max peak RSS", `${profile.summary.maxPeakRssMb} MB`],
+        ["Max RSS delta", `${profile.summary.maxRssDeltaMb} MB`],
+        ["Max CPU estimate", `${profile.summary.maxCpuMsEstimate} ms`],
+        ["Max harness heap delta", `${profile.summary.maxHarnessHeapDeltaMb} MB`],
+      ],
+      ["Metric", "Value"],
+    ),
+    "",
+    "## Target OpenClaw Registry Surface",
+    "",
+    markdownTable(
+      Object.entries(profile.targetOpenClaw).map(([key, value]) => [key, value ?? "-"]),
+      ["Metric", "Value"],
+    ),
+    "",
+    "## Plugin Fixture Surface",
+    "",
+    markdownTable(
+      Object.entries(profile.fixtureInventory).map(([key, value]) => [key, value]),
+      ["Metric", "Value"],
+    ),
+    "",
+    "## Boot And Memory Samples",
+    "",
+    markdownTable(
+      profile.commands.map((command) => [
+        command.id,
+        command.label,
+        `${command.wallMs.median} ms`,
+        `${command.wallMs.max} ms`,
+        `${command.peakRssMb.max} MB`,
+        `${command.rssDeltaMb.max} MB`,
+        `${command.cpuMsEstimate.max} ms`,
+        `${command.harnessHeapDeltaMb.max} MB`,
+        command.exitCodes.join(", "),
+      ]),
+      ["ID", "Label", "Median wall", "Max wall", "Max peak RSS", "Max RSS delta", "CPU estimate", "Heap delta", "Exit codes"],
+    ),
+    "",
+    "## Category Rollups",
+    "",
+    markdownTable(
+      (profile.groups ?? []).map((group) => [
+        group.category,
+        group.commandCount,
+        `${group.p50WallMs} ms`,
+        `${group.p95WallMs} ms`,
+        `${group.maxPeakRssMb} MB`,
+        `${group.maxCpuMsEstimate} ms`,
+        group.commands.join(", "),
+      ]),
+      ["Category", "Commands", "P50 wall", "P95 wall", "Max peak RSS", "CPU estimate", "Command IDs"],
+    ),
+  ].join("\n");
+}
+
+function summarizeTargetOpenClaw(targetOpenClaw = {}) {
+  return {
+    status: targetOpenClaw.status ?? "unknown",
+    configuredPath: targetOpenClaw.configuredPath ?? null,
+    compatRecords: targetOpenClaw.compatRecordCount ?? 0,
+    hookNames: targetOpenClaw.hookNameCount ?? 0,
+    apiRegistrars: targetOpenClaw.apiRegistrarCount ?? 0,
+    capturedRegistrars: targetOpenClaw.capturedRegistrarCount ?? 0,
+    sdkExports: targetOpenClaw.sdkExportCount ?? 0,
+    manifestFields: targetOpenClaw.manifestFieldCount ?? 0,
+    manifestContractFields: targetOpenClaw.manifestContractFieldCount ?? 0,
+  };
+}
+
+function summarizeFixtureInventory(report = {}, inspection = {}) {
+  const fixtures = report.fixtures ?? [];
+  const inspections = inspection.inspections ?? [];
+  return {
+    fixtures: fixtures.length,
+    sourceFiles: inspections.reduce((sum, item) => sum + item.sourceFiles.length, 0),
+    observedHooks: fixtures.reduce((sum, item) => sum + item.hooks.length, 0),
+    observedRegistrations: fixtures.reduce((sum, item) => sum + item.registrations.length, 0),
+    observedSdkImports: fixtures.reduce((sum, item) => sum + item.sdkImports.length, 0),
+    contractProbes: report.summary?.contractProbeCount ?? 0,
+    issueFindings: report.summary?.issueCount ?? 0,
+  };
+}
+
+function summarizeProfile(commands) {
+  const wallTimes = commands.map((command) => command.wallMs.median).sort((left, right) => left - right);
+  const maxPeakRssMb = Math.max(0, ...commands.map((command) => command.peakRssMb.max));
+  const maxRssDeltaMb = Math.max(0, ...commands.map((command) => command.rssDeltaMb.max));
+  const maxCpuMsEstimate = Math.max(0, ...commands.map((command) => command.cpuMsEstimate.max));
+  const maxHarnessHeapDeltaMb = Math.max(0, ...commands.map((command) => command.harnessHeapDeltaMb.max));
+  return {
+    commandCount: commands.length,
+    p50WallMs: percentile(wallTimes, 0.5),
+    p95WallMs: percentile(wallTimes, 0.95),
+    maxPeakRssMb,
+    maxRssDeltaMb,
+    maxCpuMsEstimate,
+    maxHarnessHeapDeltaMb,
+  };
+}
+
+function summarizeCommand(command, samples) {
+  const wallMs = samples.map((sample) => sample.wallMs).sort((left, right) => left - right);
+  const peakRssMb = samples.map((sample) => sample.peakRssMb).sort((left, right) => left - right);
+  const rssDeltaMb = samples.map((sample) => sample.rssDeltaMb).sort((left, right) => left - right);
+  const peakCpuPercent = samples.map((sample) => sample.peakCpuPercent).sort((left, right) => left - right);
+  const cpuMsEstimate = samples.map((sample) => sample.cpuMsEstimate).sort((left, right) => left - right);
+  const harnessHeapDeltaMb = samples
+    .map((sample) => sample.harnessHeapDeltaMb)
+    .sort((left, right) => left - right);
+  const commandName = command.command ?? process.execPath;
+  return {
+    id: command.id,
+    label: command.label,
+    category: command.category,
+    command: [commandName, ...(command.args ?? [])].join(" "),
+    samples,
+    wallMs: summarizeNumbers(wallMs),
+    peakRssMb: summarizeNumbers(peakRssMb),
+    rssDeltaMb: summarizeNumbers(rssDeltaMb),
+    peakCpuPercent: summarizeNumbers(peakCpuPercent),
+    cpuMsEstimate: summarizeNumbers(cpuMsEstimate),
+    harnessHeapDeltaMb: summarizeNumbers(harnessHeapDeltaMb),
+    exitCodes: [...new Set(samples.map((sample) => sample.exitCode))].sort(),
+  };
+}
+
+function summarizeCommandGroups(commands) {
+  const groups = new Map();
+  for (const command of commands) {
+    const category = command.category ?? "uncategorized";
+    const existing = groups.get(category) ?? [];
+    existing.push(command);
+    groups.set(category, existing);
+  }
+  return [...groups.entries()].map(([category, categoryCommands]) => {
+    const wallTimes = categoryCommands
+      .flatMap((command) => command.samples.map((sample) => sample.wallMs))
+      .sort((left, right) => left - right);
+    const peakRss = categoryCommands
+      .flatMap((command) => command.samples.map((sample) => sample.peakRssMb))
+      .sort((left, right) => left - right);
+    const cpuMs = categoryCommands
+      .flatMap((command) => command.samples.map((sample) => sample.cpuMsEstimate))
+      .sort((left, right) => left - right);
+    return {
+      category,
+      commandCount: categoryCommands.length,
+      p50WallMs: percentile(wallTimes, 0.5),
+      p95WallMs: percentile(wallTimes, 0.95),
+      maxPeakRssMb: peakRss.at(-1) ?? 0,
+      maxCpuMsEstimate: cpuMs.at(-1) ?? 0,
+      commands: categoryCommands.map((command) => command.id),
+    };
+  });
+}
+
+function summarizeNumbers(values) {
+  return {
+    min: values[0],
+    median: percentile(values, 0.5),
+    max: values.at(-1),
+  };
+}
+
+async function profileCommand(command, options) {
+  const args = [...(command.args ?? [])];
+  if (command.openclaw) {
+    if (options.openclawPath === false) {
+      args.push("--no-openclaw");
+    } else if (options.openclawPath) {
+      args.push("--openclaw", options.openclawPath);
+    }
+  }
+
+  const start = performance.now();
+  const heapStartMb = heapUsedMb();
+  let firstRssKb = 0;
+  let peakRssKb = 0;
+  let peakCpuPercent = 0;
+  const cpuSamples = [];
+  let pollInFlight = false;
+  const child = spawn(command.command ?? process.execPath, args, {
+    cwd: command.cwd ?? options.rootDir,
+    env: { ...process.env, ...options.env, ...command.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on("data", (chunk) => stdout.push(chunk));
+  child.stderr.on("data", (chunk) => stderr.push(chunk));
+
+  const recordStats = (stats) => {
+    if (stats.rssKb > 0 && firstRssKb === 0) {
+      firstRssKb = stats.rssKb;
+    }
+    peakRssKb = Math.max(peakRssKb, stats.rssKb);
+    peakCpuPercent = Math.max(peakCpuPercent, stats.cpuPercent);
+    if (stats.cpuPercent > 0) {
+      cpuSamples.push(stats.cpuPercent);
+    }
+  };
+  const poll = setInterval(() => {
+    if (pollInFlight) {
+      return;
+    }
+    pollInFlight = true;
+    readProcessStats(child.pid)
+      .then(recordStats)
+      .finally(() => {
+        pollInFlight = false;
+      });
+  }, 100);
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", (error) => {
+      clearInterval(poll);
+      reject(error);
+    });
+    child.on("exit", (code) => resolve(code ?? 1));
+  });
+  clearInterval(poll);
+  const finalStats = await readProcessStats(child.pid);
+  if (finalStats.rssKb > 0 && firstRssKb === 0) {
+    firstRssKb = finalStats.rssKb;
+  }
+  peakRssKb = Math.max(peakRssKb, finalStats.rssKb);
+  peakCpuPercent = Math.max(peakCpuPercent, finalStats.cpuPercent);
+  if (finalStats.cpuPercent > 0) {
+    cpuSamples.push(finalStats.cpuPercent);
+  }
+
+  const wallMs = Math.round(performance.now() - start);
+  const averageCpuPercent =
+    cpuSamples.length > 0
+      ? Math.round((cpuSamples.reduce((sum, value) => sum + value, 0) / cpuSamples.length) * 10) / 10
+      : 0;
+
+  return {
+    wallMs,
+    peakRssMb: Math.round((peakRssKb / 1024) * 10) / 10,
+    rssDeltaMb: Math.round(((peakRssKb - firstRssKb) / 1024) * 10) / 10,
+    peakCpuPercent,
+    cpuMsEstimate: Math.round((wallMs * averageCpuPercent) / 100),
+    harnessHeapDeltaMb: Math.round((heapUsedMb() - heapStartMb) * 10) / 10,
+    exitCode,
+    stdoutPreview: Buffer.concat(stdout).toString("utf8").trim().split("\n").slice(-2).join("\n"),
+    stderrPreview: Buffer.concat(stderr).toString("utf8").trim().split("\n").slice(-2).join("\n"),
+  };
+}
+
+async function readProcessStats(pid) {
+  if (!pid || process.platform === "win32") {
+    return { rssKb: 0, cpuPercent: 0 };
+  }
+  return new Promise((resolve) => {
+    const ps = spawn("ps", ["-o", "rss=", "-o", "%cpu=", "-p", String(pid)], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const chunks = [];
+    ps.stdout.on("data", (chunk) => chunks.push(chunk));
+    ps.on("error", () => resolve({ rssKb: 0, cpuPercent: 0 }));
+    ps.on("exit", () => {
+      const [rssRaw, cpuRaw] = Buffer.concat(chunks).toString("utf8").trim().split(/\s+/);
+      const rssKb = Number.parseInt(rssRaw, 10);
+      const cpuPercent = Number.parseFloat(cpuRaw);
+      resolve({
+        rssKb: Number.isFinite(rssKb) ? rssKb : 0,
+        cpuPercent: Number.isFinite(cpuPercent) ? cpuPercent : 0,
+      });
+    });
+  });
+}
+
+function heapUsedMb() {
+  return Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 10) / 10;
+}
+
+function percentile(sortedValues, percentileValue) {
+  if (sortedValues.length === 0) {
+    return 0;
+  }
+  const index = Math.min(sortedValues.length - 1, Math.ceil(sortedValues.length * percentileValue) - 1);
+  return sortedValues[index];
+}
+
+function assertRuns(runs) {
+  if (!Number.isInteger(runs) || runs < 1 || runs > 10) {
+    throw new Error("runs must be an integer between 1 and 10");
+  }
+}
+
+function resolveFromRoot(rootDir, value) {
+  return path.isAbsolute(value) ? value : path.join(rootDir, value);
+}
+
+function markdownTable(rows, headers) {
+  return renderMarkdownTable(rows, headers, { empty: "_none_", escape: false, padding: true });
+}

--- a/test/runtime-profile.test.js
+++ b/test/runtime-profile.test.js
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  buildRuntimeProfile,
+  defaultRuntimeProfileOptions,
+  renderRuntimeProfileMarkdown,
+  validateRuntimeProfile,
+  writeRuntimeProfile,
+} from "../src/index.js";
+
+test("runtime profile measures configured commands and summarizes fixture inventory", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-runtime-profile-"));
+  const profile = await buildRuntimeProfile({
+    rootDir,
+    report: reportFixture(),
+    inspection: inspectionFixture(),
+    commands: [
+      {
+        id: "fixture-command",
+        label: "Fixture command",
+        category: "fixture",
+        args: ["-e", "setTimeout(() => console.log('fixture ok'), 300)"],
+      },
+    ],
+  });
+
+  assert.equal(profile.generatedAt, defaultRuntimeProfileOptions.generatedAt);
+  assert.equal(profile.runs, 1);
+  assert.equal(profile.summary.commandCount, 1);
+  assert.equal(profile.targetOpenClaw.hookNames, 2);
+  assert.equal(profile.fixtureInventory.sourceFiles, 3);
+  assert.equal(profile.groups[0].category, "fixture");
+  assert.equal(profile.commands[0].exitCodes[0], 0);
+  assert.match(profile.commands[0].samples[0].stdoutPreview, /fixture ok/);
+  assert.deepEqual(validateRuntimeProfile(profile), []);
+  assert.match(renderRuntimeProfileMarkdown(profile), /Plugin Runtime Profile/);
+});
+
+test("runtime profile forwards OpenClaw path flags for opt-in commands", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-runtime-profile-"));
+  const argvPath = path.join(rootDir, "argv.json");
+  const recorderPath = path.join(rootDir, "recorder.mjs");
+  await writeFile(
+    recorderPath,
+    [
+      "import { writeFile } from 'node:fs/promises';",
+      "await writeFile(process.env.ARGV_OUT, JSON.stringify(process.argv.slice(2)));",
+    ].join("\n"),
+    "utf8",
+  );
+
+  await buildRuntimeProfile({
+    rootDir,
+    openclawPath: "./openclaw",
+    env: { ARGV_OUT: argvPath },
+    commands: [
+      {
+        id: "openclaw-aware",
+        label: "OpenClaw aware",
+        category: "target",
+        args: [recorderPath],
+        openclaw: true,
+      },
+    ],
+  });
+
+  assert.deepEqual(JSON.parse(await readFile(argvPath, "utf8")), ["--openclaw", "./openclaw"]);
+});
+
+test("runtime profile validates failed commands and missing metrics", () => {
+  const errors = validateRuntimeProfile({
+    platform: { rssSampler: "ps" },
+    commands: [
+      {
+        id: "failed",
+        exitCodes: [1],
+        wallMs: { max: 0 },
+        peakRssMb: { max: 0 },
+      },
+    ],
+  });
+
+  assert.ok(errors.some((error) => error.includes("nonzero exit code")));
+  assert.ok(errors.some((error) => error.includes("missing wall time")));
+  assert.ok(errors.some((error) => error.includes("missing peak RSS")));
+});
+
+test("runtime profile writer emits JSON and Markdown artifacts", async () => {
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-runtime-profile-report-"));
+  const jsonPath = path.join(outputDir, "profile.json");
+  const markdownPath = path.join(outputDir, "profile.md");
+  const profile = runtimeProfileFixture();
+
+  assert.deepEqual(await writeRuntimeProfile(profile, { jsonPath, markdownPath }), { jsonPath, markdownPath });
+  assert.equal(JSON.parse(await readFile(jsonPath, "utf8")).summary.commandCount, 1);
+  assert.match(await readFile(markdownPath, "utf8"), /Runtime Profile/);
+});
+
+function reportFixture() {
+  return {
+    targetOpenClaw: {
+      status: "ok",
+      configuredPath: "../openclaw",
+      compatRecordCount: 1,
+      hookNameCount: 2,
+      apiRegistrarCount: 3,
+      capturedRegistrarCount: 4,
+      sdkExportCount: 5,
+      manifestFieldCount: 6,
+      manifestContractFieldCount: 7,
+    },
+    fixtures: [
+      {
+        hooks: ["before_tool_call"],
+        registrations: ["registerTool"],
+        sdkImports: ["openclaw/plugin-sdk"],
+      },
+    ],
+    summary: {
+      contractProbeCount: 8,
+      issueCount: 9,
+    },
+  };
+}
+
+function inspectionFixture() {
+  return {
+    inspections: [
+      { sourceFiles: ["a.js", "b.js"] },
+      { sourceFiles: ["c.js"] },
+    ],
+  };
+}
+
+function runtimeProfileFixture() {
+  return {
+    generatedAt: "deterministic",
+    runs: 1,
+    targetOpenClaw: {
+      status: "ok",
+      configuredPath: "../openclaw",
+      compatRecords: 1,
+      hookNames: 2,
+      apiRegistrars: 3,
+      capturedRegistrars: 4,
+      sdkExports: 5,
+      manifestFields: 6,
+      manifestContractFields: 7,
+    },
+    fixtureInventory: {
+      fixtures: 1,
+      sourceFiles: 3,
+      observedHooks: 1,
+      observedRegistrations: 1,
+      observedSdkImports: 1,
+      contractProbes: 8,
+      issueFindings: 9,
+    },
+    summary: {
+      commandCount: 1,
+      p50WallMs: 10,
+      p95WallMs: 10,
+      maxPeakRssMb: 20,
+      maxRssDeltaMb: 1,
+      maxCpuMsEstimate: 2,
+      maxHarnessHeapDeltaMb: 0.1,
+    },
+    groups: [
+      {
+        category: "fixture",
+        commandCount: 1,
+        p50WallMs: 10,
+        p95WallMs: 10,
+        maxPeakRssMb: 20,
+        maxCpuMsEstimate: 2,
+        commands: ["fixture-command"],
+      },
+    ],
+    commands: [
+      {
+        id: "fixture-command",
+        label: "Fixture command",
+        category: "fixture",
+        wallMs: { median: 10, max: 10 },
+        peakRssMb: { max: 20 },
+        rssDeltaMb: { max: 1 },
+        cpuMsEstimate: { max: 2 },
+        harnessHeapDeltaMb: { max: 0.1 },
+        exitCodes: [0],
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

- add reusable runtime profile report primitives for command timing, memory sampling, target surface summaries, and Markdown/JSON artifacts
- export the runtime profile API and package subpath
- document the API and cover command profiling, OpenClaw flag forwarding, validation, and artifact writing

## Verification

- npm run check
