### PR TITLE
feat(capture): add registrar profiles

### DIFF
--- a/src/capture-api.js
+++ b/src/capture-api.js
@@ -1,15 +1,68 @@
+export const defaultCaptureApiRegistrarProfiles = {
+  registerChannel: {
+    returnValue: ({ args }) => registrationObject(args, { id: "channel" }),
+  },
+  registerCli: {
+    returnValue: ({ args }) => registrationObject(args, { name: "cli" }),
+  },
+  registerCommand: {
+    returnValue: ({ args }) => registrationObject(args, { name: "command" }),
+  },
+  registerContextEngine: {
+    returnValue: ({ args }) => registrationObject(args, { id: "context-engine" }),
+  },
+  registerGatewayMethod: {
+    returnValue: ({ args }) => registrationObject(args, { name: "gateway.method" }),
+  },
+  registerHook: {
+    returnValue: ({ api }) => api,
+  },
+  registerHttpRoute: {
+    returnValue: ({ args }) => ({
+      ...registrationObject(args, { method: "GET", path: "/" }),
+      unregister() {},
+    }),
+  },
+  registerInteractiveHandler: {
+    returnValue: ({ args }) => registrationObject(args, { id: "interactive-handler" }),
+  },
+  registerMemoryPromptSection: {
+    returnValue: ({ args }) => registrationObject(args, { id: "memory-prompt-section" }),
+  },
+  registerMemoryRuntime: {
+    returnValue: ({ args }) => registrationObject(args, { id: "memory-runtime" }),
+  },
+  registerProvider: {
+    returnValue: ({ args }) => registrationObject(args, { id: "provider" }),
+  },
+  registerService: {
+    returnValue: ({ args }) => ({
+      ...registrationObject(args, { name: "service" }),
+      start: async () => undefined,
+      stop: async () => undefined,
+    }),
+  },
+  registerSpeechProvider: {
+    returnValue: ({ args }) => registrationObject(args, { id: "speech-provider" }),
+  },
+  registerTool: {
+    returnValue: ({ args }) => registrationObject(args, { name: "tool" }),
+  },
+};
+
 export function createCaptureApi(options = {}) {
   const captured = [];
   const retained = [];
-  const knownRegistrars = new Set(options.knownRegistrars ?? []);
+  const registrarProfiles = {
+    ...defaultCaptureApiRegistrarProfiles,
+    ...(options.registrarProfiles ?? {}),
+  };
+  const knownRegistrars = new Set(options.knownRegistrars ?? Object.keys(registrarProfiles));
   const retainHandlers = options.retainHandlers === true;
 
   const api = new Proxy(
     {
-      config: options.config ?? {},
-      logger: options.logger ?? console,
-      pluginConfig: options.pluginConfig ?? {},
-      runtime: options.runtime ?? {},
+      ...createCaptureContext(options),
       on(name, handler) {
         const captureIndex =
           captured.push({
@@ -57,7 +110,7 @@ export function createCaptureApi(options = {}) {
                 captureIndex,
               });
             }
-            return registrationReturnValue(property, args);
+            return registrationReturnValue(property, args, { api, registrarProfiles });
           };
         }
         return undefined;
@@ -68,19 +121,114 @@ export function createCaptureApi(options = {}) {
   return api;
 }
 
+export function createCaptureContext(options = {}) {
+  return {
+    config: options.config ?? {},
+    logger: options.logger ?? console,
+    pluginConfig: options.pluginConfig ?? {},
+    runtime: options.runtime ?? createRuntimeContext(options),
+    secrets: options.secrets ?? createSecretContext(options),
+    store: options.store ?? createStoreContext(options),
+    paths: options.paths ?? {
+      cacheDir: ".plugin-inspector/cache",
+      configDir: ".plugin-inspector/config",
+      dataDir: ".plugin-inspector/data",
+    },
+    agent: options.agent ?? {
+      id: "plugin-inspector-agent",
+      accountId: "default",
+    },
+    gateway: options.gateway ?? {
+      baseUrl: "http://127.0.0.1:0",
+      registerRoute(route) {
+        return {
+          ...route,
+          unregister() {},
+        };
+      },
+    },
+    fetch: options.fetch ?? (async () => ({ ok: true, status: 200, json: async () => ({}), text: async () => "" })),
+  };
+}
+
 function isRegistrarProperty(property) {
   return property.startsWith("register") || property.startsWith("define");
 }
 
-function registrationReturnValue(name, args) {
-  if (name === "registerService") {
+function registrationReturnValue(name, args, context) {
+  const profile = context.registrarProfiles[name];
+  if (profile?.returnValue) {
+    return profile.returnValue({ name, args, api: context.api });
+  }
+  return registrationObject(args, {});
+}
+
+function createRuntimeContext(options) {
+  return {
+    env: options.env ?? {},
+    logger: options.logger ?? console,
+    now: () => new Date(0),
+  };
+}
+
+function createSecretContext(options) {
+  const secrets = new Map(Object.entries(options.secretValues ?? {}));
+  return {
+    async get(name) {
+      return secrets.get(name) ?? null;
+    },
+    async has(name) {
+      return secrets.has(name);
+    },
+    async require(name) {
+      if (!secrets.has(name)) {
+        throw new Error(`Missing mocked secret: ${name}`);
+      }
+      return secrets.get(name);
+    },
+    async resolve(value) {
+      return typeof value === "string" && value.startsWith("secret:") ? (secrets.get(value.slice(7)) ?? null) : value;
+    },
+  };
+}
+
+function createStoreContext() {
+  const values = new Map();
+  return {
+    async delete(key) {
+      return values.delete(key);
+    },
+    async get(key) {
+      return values.get(key);
+    },
+    async list() {
+      return [...values.keys()].sort();
+    },
+    async set(key, value) {
+      values.set(key, value);
+      return value;
+    },
+  };
+}
+
+function registrationObject(args, defaults) {
+  const first = args[0];
+  if (first && typeof first === "object") {
     return {
-      name: objectName(args[0]),
-      start: async () => undefined,
-      stop: async () => undefined,
+      ...defaults,
+      ...first,
+      name: objectName(first) ?? defaults.name,
+      id: objectId(first) ?? defaults.id,
     };
   }
-  return objectName(args[0]) ?? undefined;
+  if (typeof first === "string") {
+    return {
+      ...defaults,
+      name: first,
+      id: defaults.id,
+    };
+  }
+  return { ...defaults };
 }
 
 function summarizeArguments(args) {
@@ -112,4 +260,14 @@ function objectName(value) {
     return value.name;
   }
   return typeof value.id === "string" ? value.id : null;
+}
+
+function objectId(value) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  if (typeof value.id === "string") {
+    return value.id;
+  }
+  return typeof value.name === "string" ? value.name : null;
 }

--- a/test/capture-api.test.js
+++ b/test/capture-api.test.js
@@ -1,15 +1,15 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { createCaptureApi } from "../src/capture-api.js";
+import { createCaptureApi, defaultCaptureApiRegistrarProfiles } from "../src/capture-api.js";
 
 test("capture API records hooks and registrations", () => {
   const api = createCaptureApi({ knownRegistrars: ["registerTool"] });
 
   api.on("before_tool_call", () => undefined);
-  const registeredName = api.registerTool({ name: "search", run() {} });
+  const registeredTool = api.registerTool({ name: "search", run() {} });
   const service = api.registerService({ name: "gateway", start() {}, stop() {} });
 
-  assert.equal(registeredName, "search");
+  assert.equal(registeredTool.name, "search");
   assert.equal(service.name, "gateway");
   assert.deepEqual(
     api.getCapturedContracts().map((entry) => `${entry.kind}:${entry.name}`),
@@ -17,6 +17,50 @@ test("capture API records hooks and registrations", () => {
   );
   assert.equal(api.getCapturedContracts()[1].known, true);
   assert.equal(api.getCapturedContracts()[2].known, false);
+});
+
+test("capture API defaults to known OpenClaw registrar profiles", () => {
+  const api = createCaptureApi();
+  const provider = api.registerProvider({ id: "openai", label: "OpenAI" });
+  const route = api.registerHttpRoute({ method: "POST", path: "/webhook", handler() {} });
+
+  assert.equal(provider.id, "openai");
+  assert.equal(route.path, "/webhook");
+  assert.equal(typeof route.unregister, "function");
+  assert.equal(api.getCapturedContracts()[0].known, true);
+  assert.ok(defaultCaptureApiRegistrarProfiles.registerTool);
+});
+
+test("capture API accepts custom registrar return profiles", () => {
+  const api = createCaptureApi({
+    registrarProfiles: {
+      registerCustomThing: {
+        returnValue: ({ args }) => ({ custom: args[0].name }),
+      },
+    },
+  });
+
+  const registered = api.registerCustomThing({ name: "fixture" });
+
+  assert.deepEqual(registered, { custom: "fixture" });
+  assert.equal(api.getCapturedContracts()[0].known, true);
+});
+
+test("capture API exposes mock context helpers", async () => {
+  const api = createCaptureApi({
+    secretValues: {
+      token: "redacted",
+    },
+  });
+
+  await api.store.set("key", { value: 1 });
+
+  assert.equal(await api.secrets.get("token"), "redacted");
+  assert.equal(await api.secrets.resolve("secret:token"), "redacted");
+  assert.deepEqual(await api.store.get("key"), { value: 1 });
+  assert.deepEqual(await api.store.list(), ["key"]);
+  assert.equal(api.agent.id, "plugin-inspector-agent");
+  assert.equal(api.paths.dataDir, ".plugin-inspector/data");
 });
 
 test("capture API can retain handlers for probes", () => {


### PR DESCRIPTION
## What
- add default capture API profiles for common OpenClaw registrars
- return registrar-shaped mock handles for providers, routes, services, tools, channels, and related contracts
- add reusable mock context defaults for secrets, store, paths, agent, gateway, runtime, and fetch

## Why
Runtime capture should behave more like a plugin host. Plugin code often keeps the return value from a registrar or expects host context helpers to exist, and the previous generic string/undefined returns were too thin.

## Impact
- callers can still pass `knownRegistrars` to constrain known/unknown classification
- custom registrar profiles can extend the mock host without changing package code
- no runtime dependencies added

## Checks
- `node --test test/capture-api.test.js`
- `npm run release:local`
