### PR TITLE
feat(probes): enrich lifecycle capture

### DIFF
--- a/src/capture-api.js
+++ b/src/capture-api.js
@@ -95,6 +95,7 @@ export function createCaptureApi(options = {}) {
         }
         if (typeof property === "string" && isRegistrarProperty(property)) {
           return (...args) => {
+            const returnValue = registrationReturnValue(property, args, { api, registrarProfiles });
             const captureIndex =
               captured.push({
                 kind: "registration",
@@ -107,10 +108,11 @@ export function createCaptureApi(options = {}) {
                 kind: "registration",
                 name: property,
                 arguments: args,
+                returnValue,
                 captureIndex,
               });
             }
-            return registrationReturnValue(property, args, { api, registrarProfiles });
+            return returnValue;
           };
         }
         return undefined;

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -156,7 +156,12 @@ export async function captureEntrypoint(entrypoint, options = {}) {
   }
 
   const resolvedEntrypoint = path.resolve(options.cwd ?? process.cwd(), entrypoint);
-  const module = await import(pathToFileURL(resolvedEntrypoint).href);
+  let module;
+  try {
+    module = await import(pathToFileURL(resolvedEntrypoint).href);
+  } catch (error) {
+    throw classifyCapturePhaseError(error, "entrypoint-import-error");
+  }
   const register = findRegisterExport(module);
 
   if (!register) {
@@ -168,7 +173,11 @@ export async function captureEntrypoint(entrypoint, options = {}) {
   }
 
   const api = createCaptureApi(options.apiOptions);
-  await register(api);
+  try {
+    await register(api);
+  } catch (error) {
+    throw classifyCapturePhaseError(error, "registration-execution-error");
+  }
   const result = {
     status: "captured",
     entrypoint: resolvedEntrypoint,
@@ -229,9 +238,24 @@ export function classifyMockSdkCaptureError(error) {
     });
   }
 
+  const failureClass = rawMessage.match(/\[plugin-inspector:([^\]]+)\]/)?.[1];
+  if (failureClass) {
+    return enrichCaptureError(error, {
+      message: firstMeaningfulErrorLine(rawMessage.replace(/\[plugin-inspector:[^\]]+\]/, "")) ?? "Mock SDK capture failed",
+      failureClass,
+    });
+  }
+
   return enrichCaptureError(error, {
     message: firstMeaningfulErrorLine(rawMessage) ?? "Mock SDK capture failed",
     failureClass: "mock-sdk-capture-error",
+  });
+}
+
+export function classifyCapturePhaseError(error, failureClass) {
+  return enrichCaptureError(error, {
+    message: error instanceof Error ? error.message : String(error),
+    failureClass,
   });
 }
 

--- a/src/mock-sdk-capture-runner.js
+++ b/src/mock-sdk-capture-runner.js
@@ -12,6 +12,9 @@ try {
   const result = await run(options);
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 } catch (error) {
+  if (error.failureClass) {
+    process.stderr.write(`[plugin-inspector:${error.failureClass}]\n`);
+  }
   process.stderr.write(`${error.stack ?? error.message}\n`);
   process.exitCode = 1;
 }
@@ -33,7 +36,12 @@ async function run(options) {
 }
 
 async function captureLinkedEntrypoint(entrypoint, options) {
-  const module = await import(pathToFileURL(entrypoint).href);
+  let module;
+  try {
+    module = await import(pathToFileURL(entrypoint).href);
+  } catch (error) {
+    throw capturePhaseError(error, "entrypoint-import-error");
+  }
   const register = findRegisterExport(module);
 
   if (!register) {
@@ -46,13 +54,26 @@ async function captureLinkedEntrypoint(entrypoint, options) {
   }
 
   const api = createCaptureApi(options.apiOptions);
-  await register(api);
-  return {
+  try {
+    await register(api);
+  } catch (error) {
+    throw capturePhaseError(error, "registration-execution-error");
+  }
+  const result = {
     status: "captured",
     entrypoint: options.entrypoint,
     mockSdk: true,
     captured: api.getCapturedContracts(),
   };
+  if (options.apiOptions?.retainHandlers === true) {
+    result.retained = api.getRetainedContracts();
+  }
+  return result;
+}
+
+function capturePhaseError(error, failureClass) {
+  error.failureClass = failureClass;
+  return error;
 }
 
 function findRegisterExport(module) {

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -203,6 +203,47 @@ export const defaultSyntheticRegistrationArguments = {
   registerTool: [{ name: "fixture_tool", inputSchema: { type: "object", properties: {} }, run: "function" }],
 };
 
+export const defaultSyntheticRegistrationProbeInputs = {
+  registerCli: {
+    execute: commandProbeArgs,
+    handler: commandProbeArgs,
+    run: commandProbeArgs,
+  },
+  registerCommand: {
+    execute: commandProbeArgs,
+    handler: commandProbeArgs,
+    run: commandProbeArgs,
+  },
+  registerGatewayMethod: {
+    execute: gatewayProbeArgs,
+    handler: gatewayProbeArgs,
+    run: gatewayProbeArgs,
+  },
+  registerHttpRoute: {
+    execute: httpRouteProbeArgs,
+    handler: httpRouteProbeArgs,
+    run: httpRouteProbeArgs,
+  },
+  registerInteractiveHandler: {
+    execute: interactiveProbeArgs,
+    handler: interactiveProbeArgs,
+    run: interactiveProbeArgs,
+  },
+  registerService: {
+    start: lifecycleProbeArgs,
+    stop: lifecycleProbeArgs,
+  },
+  registerSpeechProvider: {
+    speak: speechProbeArgs,
+    synthesize: speechProbeArgs,
+  },
+  registerTool: {
+    execute: toolExecuteProbeArgs,
+    handler: toolRunProbeArgs,
+    run: toolRunProbeArgs,
+  },
+};
+
 export function buildSyntheticProbePlan(options = {}) {
   if (!options.capture) {
     throw new TypeError("buildSyntheticProbePlan requires a capture inventory");
@@ -411,7 +452,7 @@ async function runRegistrationProbes(entry, retainedEntry, captureIndex, options
     return [metadataOnlyResult(entry, captureIndex, profile.reason)];
   }
 
-  const descriptor = retainedEntry.arguments?.[0];
+  const descriptor = retainedEntry.arguments?.[0] ?? retainedEntry.returnValue;
   if (!descriptor || typeof descriptor !== "object") {
     return [blockedResult(entry, captureIndex, "captured registration has no object descriptor")];
   }
@@ -419,7 +460,7 @@ async function runRegistrationProbes(entry, retainedEntry, captureIndex, options
     return [blockedResult(entry, captureIndex, `captured registration requires ${profile.option}=true`)];
   }
 
-  const invocations = registrationInvocations(entry.name, descriptor, profile, options);
+  const invocations = registrationInvocations(entry.name, descriptor, retainedEntry.returnValue, profile, options);
   if (invocations.length === 0) {
     return [blockedResult(entry, captureIndex, "captured registration has no supported callable probe")];
   }
@@ -437,14 +478,21 @@ async function runRegistrationProbes(entry, retainedEntry, captureIndex, options
   );
 }
 
-function registrationInvocations(registrar, descriptor, profile, options) {
+function registrationInvocations(registrar, descriptor, returnValue, profile, options) {
   const invocations = [];
+  const allowReturnValueFallback = descriptor === returnValue;
 
   for (const property of profile.callableProperties) {
-    if (typeof descriptor[property] === "function") {
+    const callable =
+      typeof descriptor[property] === "function"
+        ? descriptor[property]
+        : allowReturnValueFallback
+          ? returnValue?.[property]
+          : undefined;
+    if (typeof callable === "function") {
       invocations.push({
         label: `${registrar}.${property}`,
-        invoke: () => invokeRegistrationCallable(descriptor[property], registrar, property, options),
+        invoke: () => invokeRegistrationCallable(callable, registrar, property, options),
       });
     }
   }
@@ -453,10 +501,9 @@ function registrationInvocations(registrar, descriptor, profile, options) {
 
 function invokeRegistrationCallable(callable, registrar, property, options) {
   const event = syntheticRegistrationEvent(registrar, property, options);
-  if (property === "execute") {
-    return callable("call-fixture", event.params, new AbortController().signal, () => undefined);
-  }
-  return callable(event);
+  const inputFactory = options.registrationProbeInputs?.[registrar]?.[property] ?? defaultSyntheticRegistrationProbeInputs[registrar]?.[property];
+  const args = inputFactory ? inputFactory(event, options) : [event];
+  return callable(...args);
 }
 
 function syntheticRegistrationEvent(registrar, property, options) {
@@ -476,6 +523,103 @@ function syntheticRegistrationEvent(registrar, property, options) {
       name: beforeToolCall.toolName,
     },
   };
+}
+
+function toolRunProbeArgs(event) {
+  return [
+    event.params,
+    {
+      source: event.source,
+      toolName: event.toolName,
+      toolCallId: event.toolCall.id,
+      signal: new AbortController().signal,
+      logger: console,
+    },
+  ];
+}
+
+function toolExecuteProbeArgs(event) {
+  return [event.toolCall.id, event.params, new AbortController().signal, () => undefined];
+}
+
+function httpRouteProbeArgs(event) {
+  return [
+    {
+      method: "POST",
+      path: "/fixture/probe",
+      url: "http://127.0.0.1/fixture/probe",
+      headers: event.headers,
+      body: event.body,
+      json: async () => event.body,
+      text: async () => JSON.stringify(event.body),
+    },
+    {
+      source: event.source,
+      params: event.params,
+      logger: console,
+    },
+  ];
+}
+
+function commandProbeArgs(event) {
+  return [
+    event.input,
+    {
+      source: event.source,
+      signal: new AbortController().signal,
+      logger: console,
+    },
+  ];
+}
+
+function gatewayProbeArgs(event) {
+  return [
+    {
+      params: event.params,
+      body: event.body,
+      headers: event.headers,
+    },
+    {
+      source: event.source,
+      logger: console,
+    },
+  ];
+}
+
+function interactiveProbeArgs(event) {
+  return [
+    {
+      id: "interaction-fixture",
+      payload: event.body,
+    },
+    {
+      source: event.source,
+      logger: console,
+    },
+  ];
+}
+
+function lifecycleProbeArgs(event) {
+  return [
+    {
+      source: event.source,
+      logger: console,
+      signal: new AbortController().signal,
+    },
+  ];
+}
+
+function speechProbeArgs(event) {
+  return [
+    {
+      text: "fixture speech request",
+      voice: "fixture",
+    },
+    {
+      source: event.source,
+      logger: console,
+    },
+  ];
 }
 
 async function runProbe({ captureIndex, kind, seam, label, invoke }) {

--- a/test/capture-api.test.js
+++ b/test/capture-api.test.js
@@ -68,8 +68,11 @@ test("capture API can retain handlers for probes", () => {
   const api = createCaptureApi({ retainHandlers: true });
 
   api.on("llm_output", handler);
+  const service = api.registerService({ name: "fixture-service" });
 
   const retained = api.getRetainedContracts();
-  assert.equal(retained.length, 1);
+  assert.equal(retained.length, 2);
   assert.equal(retained[0].handler, handler);
+  assert.equal(retained[1].returnValue, service);
+  assert.equal(typeof retained[1].returnValue.start, "function");
 });

--- a/test/runtime-capture-report.test.js
+++ b/test/runtime-capture-report.test.js
@@ -109,3 +109,44 @@ test("runtime capture report classifies missing mocked SDK exports", async () =>
   });
   assert.match(await readFile(path.join(outDir, "capture.md"), "utf8"), /missing-sdk-export/);
 });
+
+test("runtime capture report classifies registration execution failures", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-runtime-capture-registration-error-"));
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "openclaw-registration-error",
+        version: "1.0.0",
+        type: "module",
+        openclaw: {
+          extensions: ["src/index.mjs"],
+          compat: { pluginApi: "^1.0.0" },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "src", "index.mjs"),
+    [
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      "",
+      "export default definePluginEntry(() => {",
+      "  throw new Error('register exploded');",
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const config = await loadPluginRootConfig(null, { cwd: rootDir });
+  const compatibilityReport = await inspectCompatibilityFixtureSet(config, { openclawPath: false });
+  const captureReport = await buildRuntimeCaptureReport({ report: compatibilityReport, rootDir });
+
+  assert.equal(captureReport.summary.failedCount, 1);
+  assert.equal(captureReport.results[0].failureClass, "registration-execution-error");
+  assert.match(captureReport.results[0].error, /register exploded/);
+});

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -96,6 +96,30 @@ test("synthetic probes invoke retained hook and tool handlers", async () => {
   );
 });
 
+test("synthetic probes pass registrar-specific handler inputs", async () => {
+  const capture = await captureLocalFixture([
+    "export function register(api) {",
+    "  api.registerTool({",
+    "    name: 'fixture_tool',",
+    "    run(params, ctx) { return { sawParams: typeof params === 'object', toolName: ctx.toolName }; },",
+    "  });",
+    "  api.registerHttpRoute({",
+    "    method: 'POST',",
+    "    path: '/fixture',",
+    "    handler(req, ctx) { return { method: req.method, hasLogger: Boolean(ctx.logger) }; },",
+    "  });",
+    "}",
+  ]);
+
+  const result = await runCapturedSyntheticProbes(capture);
+
+  assert.equal(result.summary.failCount, 0);
+  assert.deepEqual(
+    result.results.map((item) => `${item.status}:${item.label}`),
+    ["pass:registerTool.run", "pass:registerHttpRoute.handler"],
+  );
+});
+
 test("synthetic probes keep opt-in registrations guarded", async () => {
   const capture = await captureLocalFixture([
     "export function register(api) {",
@@ -110,6 +134,34 @@ test("synthetic probes keep opt-in registrations guarded", async () => {
   const executed = await runCapturedSyntheticProbes(capture, { includeLifecycle: true });
   assert.equal(executed.summary.passCount, 1);
   assert.equal(executed.results[0].label, "registerService.start");
+});
+
+test("mock SDK capture preserves retained registration metadata across subprocesses", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-mock-sdk-"));
+  const entrypoint = path.join(dir, "fixture.mjs");
+  await writeFile(
+    entrypoint,
+    [
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      "",
+      "export default definePluginEntry((api) => {",
+      "  api.registerTool({ name: 'fixture_tool', run(params) { return { sawParams: typeof params === 'object' }; } });",
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const capture = await captureEntrypoint("fixture.mjs", {
+    cwd: dir,
+    pluginRoot: dir,
+    mockSdk: true,
+    apiOptions: { retainHandlers: true },
+  });
+  const result = await runCapturedSyntheticProbes(capture);
+
+  assert.equal(capture.retained.length, 1);
+  assert.equal(result.summary.blockedCount, 1);
+  assert.match(result.results[0].reason, /no supported callable probe/);
 });
 
 async function captureLocalFixture(lines) {


### PR DESCRIPTION
## What
- retain registrar return values when handler retention is enabled
- add registrar-specific synthetic invocation inputs for tools, commands, routes, gateway methods, lifecycle hooks, interactive handlers, and speech providers
- preserve retained capture metadata from mock-SDK subprocess capture
- classify entrypoint import and registration execution failures in runtime capture reports

## Why
The inspector needs to behave more like a host when probing captured handlers. One generic event object was too weak for tool/route/command handlers, and runtime failures needed to say whether import or registration actually failed.

## Impact
- richer synthetic probes for retained local captures
- mock-SDK subprocess captures expose retained metadata, while callable JS functions remain intentionally blocked after JSON serialization
- runtime report JSON gets clearer `failureClass` values for import and register failures

## Checks
- `node --test test/capture-api.test.js test/synthetic-probes.test.js test/runtime-capture-report.test.js`
- `npm run release:local`
