### PR TITLE
fix(cli): report log count in text summary

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -160,6 +160,7 @@ export async function buildCompatibilityReport(options = {}) {
       warningCount: warnings.length,
       suggestionCount: suggestions.length,
       decisionCount: decisions.length,
+      logCount: logs.length,
       issueCount: issues.length,
       p0IssueCount: issues.filter((issue) => issue.severity === "P0").length,
       p1IssueCount: issues.filter((issue) => issue.severity === "P1").length,

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -47,6 +47,9 @@ test("check command runs from a plugin root without fixture config", async () =>
   const issues = await readFile(path.join(rootDir, "reports", "plugin-inspector-issues.md"), "utf8");
 
   assert.match(stdout, /Status: PASS/);
+  assert.equal(report.summary.logCount, report.logs.length);
+  assert.match(stdout, new RegExp(`Logs: ${report.logs.length}\\b`));
+  assert.doesNotMatch(stdout, /Logs: undefined/);
   assert.equal(report.targetOpenClaw.status, "disabled");
   assert.equal(report.fixtures[0].id, "weather");
   assert.ok(report.fixtures[0].package.openclaw.entrypoints.some((entrypoint) => entrypoint.exists));


### PR DESCRIPTION
## Summary

Fix the CLI text summary so `plugin-inspector check` reports the actual log count instead of printing `Logs: undefined`.

## What changed

- add `summary.logCount` to the compatibility report summary
- strengthen the CLI test to verify the summary log count matches the actual logs array
- assert the CLI output no longer prints `Logs: undefined`

## Why

The CLI summary renderer already expected `report.summary.logCount`, but the compatibility report builder was not populating it. That made normal successful runs print a broken summary line even though the underlying report data was otherwise fine.

## Verification

- `npm run check`

Result:
- tests passing: 99/99
- `npm pack --dry-run` passing
