### PR TITLE
feat: flag reserved SDK imports

### DIFF
--- a/src/advanced.js
+++ b/src/advanced.js
@@ -100,6 +100,7 @@ export {
   openClawTargetPathCandidates,
   parseCompatRecordEntries,
   parseExportedStringArray,
+  parsePluginSdkEntrypointSpecifiers,
   parsePluginSdkExports,
   parseTypeFields,
   readOpenClawTargetSurface,

--- a/src/contract-probes.js
+++ b/src/contract-probes.js
@@ -29,6 +29,11 @@ export const contractProbeRules = {
     contract: "Every observed OpenClaw plugin SDK import remains exported by the target OpenClaw package.",
     target: "sdk-alias",
   },
+  "reserved-sdk-import": {
+    id: "sdk.import.reserved-bundled-plugin-boundary",
+    contract: "External plugins use documented public SDK subpaths instead of reserved bundled-plugin compatibility shims.",
+    target: "sdk-import",
+  },
   "provider-auth-env-vars": {
     id: "manifest.compat.provider-auth-env-vars",
     contract: "Legacy provider auth env metadata continues to map into config/help surfaces.",

--- a/src/fixture-summary.js
+++ b/src/fixture-summary.js
@@ -626,7 +626,12 @@ function classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, war
 
   const sdkExports = new Set(targetOpenClaw.sdkExports);
   const unknownImports = fixtureReport.sdkImportDetails.filter((sdkImport) => !sdkExports.has(sdkImport.specifier));
-  if (unknownImports.length === 0) {
+  const reservedSdkExports = new Set(targetOpenClaw.reservedSdkExports ?? []);
+  const reservedImports = fixtureReport.sdkImportDetails.filter((sdkImport) =>
+    reservedSdkExports.has(sdkImport.specifier),
+  );
+
+  if (reservedImports.length === 0 && unknownImports.length === 0) {
     logs.push({
       fixture: fixture.id,
       code: "sdk-exports-present",
@@ -637,21 +642,40 @@ function classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, war
     return;
   }
 
-  warnings.push({
-    fixture: fixture.id,
-    code: "sdk-export-missing",
-    level: "warning",
-    message: "fixture imports plugin SDK aliases that are not exported by the target OpenClaw package",
-    evidence: detailEvidence(unknownImports, "specifier"),
-    compatRecord: "plugin-sdk-export-aliases",
-  });
-  decisions.push({
-    fixture: fixture.id,
-    decision: "core-compat-adapter",
-    seam: "sdk-alias",
-    action: "Restore the package export alias or publish a versioned migration map before cold-importing old plugins.",
-    evidence: unique(unknownImports.map((sdkImport) => sdkImport.specifier)).join(", "),
-  });
+  if (unknownImports.length > 0) {
+    warnings.push({
+      fixture: fixture.id,
+      code: "sdk-export-missing",
+      level: "warning",
+      message: "fixture imports plugin SDK aliases that are not exported by the target OpenClaw package",
+      evidence: detailEvidence(unknownImports, "specifier"),
+      compatRecord: "plugin-sdk-export-aliases",
+    });
+    decisions.push({
+      fixture: fixture.id,
+      decision: "core-compat-adapter",
+      seam: "sdk-alias",
+      action: "Restore the package export alias or publish a versioned migration map before cold-importing old plugins.",
+      evidence: unique(unknownImports.map((sdkImport) => sdkImport.specifier)).join(", "),
+    });
+  }
+
+  if (reservedImports.length > 0) {
+    warnings.push({
+      fixture: fixture.id,
+      code: "reserved-sdk-import",
+      level: "warning",
+      message: "fixture imports reserved bundled-plugin SDK compatibility subpaths",
+      evidence: detailEvidence(reservedImports, "specifier"),
+    });
+    decisions.push({
+      fixture: fixture.id,
+      decision: "plugin-upstream-fix",
+      seam: "sdk-import",
+      action: "Move the plugin to documented public SDK subpaths or plugin-local helpers before relying on this compatibility shim.",
+      evidence: unique(reservedImports.map((sdkImport) => sdkImport.specifier)).join(", "),
+    });
+  }
 }
 
 function classifyManifestFieldCoverage({ fixture, fixtureReport, targetOpenClaw, warnings, logs, decisions }) {

--- a/src/issues.js
+++ b/src/issues.js
@@ -32,6 +32,7 @@ export const knownIssueCodes = new Set([
   "provider-auth-env-vars",
   "registration-capture-gap",
   "runtime-tool-capture",
+  "reserved-sdk-import",
   "sdk-export-missing",
 ]);
 
@@ -77,6 +78,12 @@ export const issueMetadataByCode = {
     owner: "core",
     decision: "core-compat-adapter",
     title: "plugin SDK import aliases are missing from target package exports",
+  },
+  "reserved-sdk-import": {
+    severity: "P1",
+    owner: "plugin",
+    decision: "plugin-upstream-fix",
+    title: "plugin imports reserved bundled-plugin SDK compatibility subpaths",
   },
   "missing-compat-record": {
     severity: "P1",
@@ -310,6 +317,7 @@ function issueClassFor(code, options) {
       "package-openclaw-entry-missing",
       "package-openclaw-metadata-missing",
       "package-plugin-api-compat-missing",
+      "reserved-sdk-import",
     ].includes(code)
   ) {
     return "upstream-metadata";

--- a/src/openclaw-target.js
+++ b/src/openclaw-target.js
@@ -31,6 +31,7 @@ export async function readOpenClawTargetSurface(options = {}) {
   const apiBuilderPath = path.join(resolvedPath, "src/plugins/api-builder.ts");
   const capturedRegistrationPath = path.join(resolvedPath, "src/plugins/captured-registration.ts");
   const manifestTypesPath = path.join(resolvedPath, "src/plugins/manifest.ts");
+  const pluginSdkEntrypointsPath = path.join(resolvedPath, "src/plugin-sdk/entrypoints.ts");
   const packagePath = path.join(resolvedPath, "package.json");
 
   const registrySource = await readFile(registryPath, "utf8");
@@ -47,6 +48,18 @@ export async function readOpenClawTargetSurface(options = {}) {
     : [];
   const sdkExports = existsSync(packagePath)
     ? parsePluginSdkExports(JSON.parse(await readFile(packagePath, "utf8")))
+    : [];
+  const pluginSdkEntrypointsSource = existsSync(pluginSdkEntrypointsPath)
+    ? await readFile(pluginSdkEntrypointsPath, "utf8")
+    : "";
+  const reservedSdkExports = pluginSdkEntrypointsSource
+    ? parsePluginSdkEntrypointSpecifiers(pluginSdkEntrypointsSource, "reservedBundledPluginSdkEntrypoints")
+    : [];
+  const supportedFacadeSdkExports = pluginSdkEntrypointsSource
+    ? parsePluginSdkEntrypointSpecifiers(pluginSdkEntrypointsSource, "supportedBundledFacadeSdkEntrypoints")
+    : [];
+  const publicPluginOwnedSdkExports = pluginSdkEntrypointsSource
+    ? parsePluginSdkEntrypointSpecifiers(pluginSdkEntrypointsSource, "publicPluginOwnedSdkEntrypoints")
     : [];
 
   return {
@@ -69,6 +82,13 @@ export async function readOpenClawTargetSurface(options = {}) {
     packagePath: existsSync(packagePath) ? relativePath(rootDir, packagePath) : null,
     sdkExportCount: sdkExports.length,
     sdkExports,
+    pluginSdkEntrypointsPath: existsSync(pluginSdkEntrypointsPath)
+      ? relativePath(rootDir, pluginSdkEntrypointsPath)
+      : null,
+    reservedSdkExportCount: reservedSdkExports.length,
+    reservedSdkExports,
+    supportedFacadeSdkExports,
+    publicPluginOwnedSdkExports,
     manifestTypesPath: existsSync(manifestTypesPath) ? relativePath(rootDir, manifestTypesPath) : null,
     manifestFieldCount: manifestFields.length,
     manifestFields,
@@ -149,9 +169,16 @@ function emptyTargetSurface({ configuredPath, searchedPaths = undefined, status 
     apiRegistrars: [],
     capturedRegistrars: [],
     sdkExports: [],
+    reservedSdkExports: [],
+    supportedFacadeSdkExports: [],
+    publicPluginOwnedSdkExports: [],
     manifestFields: [],
     manifestContractFields: [],
   };
+}
+
+export function parsePluginSdkEntrypointSpecifiers(source, exportName) {
+  return parseExportedStringArray(source, exportName).map((entrypoint) => `openclaw/plugin-sdk/${entrypoint}`).sort();
 }
 
 function parseCapturedRegistrars(source) {

--- a/test/issues.test.js
+++ b/test/issues.test.js
@@ -96,6 +96,7 @@ test("issue builder applies metadata and class summaries", () => {
   });
 
   assert.ok(knownIssueCodes.has("sdk-export-missing"));
+  assert.ok(knownIssueCodes.has("reserved-sdk-import"));
   assert.deepEqual(
     issues.map((issue) => [issue.fixture, issue.code, issue.severity, issue.issueClass, issue.status]),
     [

--- a/test/openclaw-target.test.js
+++ b/test/openclaw-target.test.js
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import {
   openClawTargetPathCandidates,
   parseCompatRecordEntries,
+  parsePluginSdkEntrypointSpecifiers,
   parsePluginSdkExports,
   parseTypeFields,
   readOpenClawTargetSurface,
@@ -69,6 +70,14 @@ export type PluginManifestContracts = {
     }),
     "utf8",
   );
+  await mkdir(path.join(targetRoot, "src/plugin-sdk"), { recursive: true });
+  await writeFile(
+    path.join(targetRoot, "src/plugin-sdk/entrypoints.ts"),
+    `export const reservedBundledPluginSdkEntrypoints = ["browser-security-runtime"] as const;
+export const supportedBundledFacadeSdkEntrypoints = ["lmstudio"] as const;
+export const publicPluginOwnedSdkEntrypoints = ["speech-core"] as const;\n`,
+    "utf8",
+  );
 
   const target = await readOpenClawTargetSurface({
     rootDir,
@@ -89,6 +98,9 @@ export type PluginManifestContracts = {
   assert.deepEqual(target.apiRegistrars, ["registerService", "registerTool"]);
   assert.deepEqual(target.capturedRegistrars, ["registerService", "registerTool"]);
   assert.deepEqual(target.sdkExports, ["openclaw/plugin-sdk", "openclaw/plugin-sdk/channels"]);
+  assert.deepEqual(target.reservedSdkExports, ["openclaw/plugin-sdk/browser-security-runtime"]);
+  assert.deepEqual(target.supportedFacadeSdkExports, ["openclaw/plugin-sdk/lmstudio"]);
+  assert.deepEqual(target.publicPluginOwnedSdkExports, ["openclaw/plugin-sdk/speech-core"]);
   assert.deepEqual(target.manifestFields, ["contracts", "id"]);
   assert.deepEqual(target.manifestContractFields, ["channels", "tools"]);
   assert.equal(target.compatRegistryPath, "openclaw/src/plugins/compat/registry.ts");
@@ -115,6 +127,13 @@ test("OpenClaw target parsing helpers stay deterministic", () => {
     "openclaw/plugin-sdk",
     "openclaw/plugin-sdk/tools",
   ]);
+  assert.deepEqual(
+    parsePluginSdkEntrypointSpecifiers(
+      'export const reservedBundledPluginSdkEntrypoints = ["browser-security-runtime", "matrix"] as const;',
+      "reservedBundledPluginSdkEntrypoints",
+    ),
+    ["openclaw/plugin-sdk/browser-security-runtime", "openclaw/plugin-sdk/matrix"],
+  );
   assert.deepEqual(
     parseCompatRecordEntries(`
       { code: "b", status: "supported" }

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -361,8 +361,14 @@ test("target OpenClaw coverage classifier reports missing public surface", () =>
       registrationDetails: [{ name: "registerMissing", ref: "plugins/fixture/src/index.ts:2" }],
     },
     fixtureReport: {
-      sdkImports: ["openclaw/plugin-sdk/missing"],
-      sdkImportDetails: [{ specifier: "openclaw/plugin-sdk/missing", ref: "plugins/fixture/src/index.ts:3" }],
+      sdkImports: ["openclaw/plugin-sdk/browser-security-runtime", "openclaw/plugin-sdk/missing"],
+      sdkImportDetails: [
+        {
+          specifier: "openclaw/plugin-sdk/browser-security-runtime",
+          ref: "plugins/fixture/src/index.ts:3",
+        },
+        { specifier: "openclaw/plugin-sdk/missing", ref: "plugins/fixture/src/index.ts:4" },
+      ],
       pluginManifests: [
         {
           path: "plugins/fixture/openclaw.plugin.json",
@@ -375,7 +381,8 @@ test("target OpenClaw coverage classifier reports missing public surface", () =>
       status: "ok",
       hookNames: ["known_hook"],
       apiRegistrars: ["registerTool"],
-      sdkExports: ["openclaw/plugin-sdk"],
+      sdkExports: ["openclaw/plugin-sdk", "openclaw/plugin-sdk/browser-security-runtime"],
+      reservedSdkExports: ["openclaw/plugin-sdk/browser-security-runtime"],
       manifestFields: ["id"],
       manifestContractFields: ["tools"],
     },
@@ -383,6 +390,7 @@ test("target OpenClaw coverage classifier reports missing public surface", () =>
 
   assert.ok(result.warnings.some((finding) => finding.code === "unknown-hook-name"));
   assert.ok(result.warnings.some((finding) => finding.code === "unknown-registration-name"));
+  assert.ok(result.warnings.some((finding) => finding.code === "reserved-sdk-import"));
   assert.ok(result.warnings.some((finding) => finding.code === "sdk-export-missing"));
   assert.ok(result.warnings.some((finding) => finding.code === "manifest-unknown-fields"));
   assert.ok(result.warnings.some((finding) => finding.code === "manifest-unknown-contracts"));


### PR DESCRIPTION
## Summary
- parse OpenClaw SDK entrypoint metadata from target checkouts
- flag external plugin imports of reserved bundled-plugin SDK compatibility subpaths
- add issue metadata and contract probe rows for reserved SDK boundary violations

## Verification
- npm run check
- patched CLI against valid fixture: pass, no issues
- patched CLI against bad fixture: reports reserved-sdk-import
- published @openclaw/plugin-inspector@0.1.0 against bad fixture: passes silently (confirmed gap)