### PR TITLE
fix(cli): wire ci command to ci summary artifacts

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,9 +4,11 @@ import {
   runPluginCheck,
 } from "./index.js";
 import {
+  buildCiSummary,
   captureEntrypoint,
   inspectFixtureSet,
   loadInspectorConfig,
+  writeCiSummary,
   writePluginInspectorInit,
   writeArtifacts,
   writeReport,
@@ -23,8 +25,10 @@ try {
     await runCheck(commandArgs);
   } else if (command === "init") {
     await runInit(commandArgs);
-  } else if (command === "inspect" || command === "report" || command === "ci") {
+  } else if (command === "inspect" || command === "report") {
     await runReport(command, commandArgs);
+  } else if (command === "ci") {
+    await runCi(commandArgs);
   } else if (command === "capture") {
     await runCapture(commandArgs);
   } else {
@@ -95,6 +99,39 @@ async function runReport(command, commandArgs) {
   }
 }
 
+async function runCi(commandArgs) {
+  const configPath = readFlag(commandArgs, "--config");
+  const outDir = readFlag(commandArgs, "--out") ?? "reports";
+  const json = commandArgs.includes("--json");
+  const config = await loadInspectorConfig(configPath);
+  const report = await inspectFixtureSet(config);
+  await writeReport(report, { outDir });
+
+  const summary = await buildCiSummary({
+    artifactBaseDir: outDir,
+    reportPaths: {
+      compatibility: "plugin-inspector-report.json",
+    },
+    reports: {
+      compatibility: report,
+    },
+  });
+  await writeCiSummary(summary, {
+    jsonPath: `${outDir}/plugin-inspector-ci-summary.json`,
+    markdownPath: `${outDir}/plugin-inspector-ci-summary.md`,
+  });
+
+  if (json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(renderCiTextSummary(summary));
+  }
+
+  if (summary.status !== "pass") {
+    throw new Error("plugin-inspector ci summary failed");
+  }
+}
+
 async function runCapture(commandArgs) {
   const entrypoint = commandArgs.find((arg) => !arg.startsWith("-"));
   const outputPath = readFlag(commandArgs, "--output");
@@ -152,6 +189,15 @@ function readMockSdkFlag(commandArgs) {
     return false;
   }
   return undefined;
+}
+
+function renderCiTextSummary(summary) {
+  return [
+    `Status: ${summary.status.toUpperCase()}`,
+    `Breakages: ${summary.summary.breakages}`,
+    `Issues: ${summary.summary.issues}`,
+    `Artifacts: ${Object.values(summary.artifacts).filter(Boolean).length}`,
+  ].join("\n");
 }
 
 function printHelp() {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import path from "node:path";
 import {
   renderTextSummary,
   runPluginCheck,
@@ -6,9 +7,11 @@ import {
 import {
   buildCiSummary,
   captureEntrypoint,
+  inspectCompatibilityFixtureSet,
   inspectFixtureSet,
   loadInspectorConfig,
   writeCiSummary,
+  writeCompatibilityReport,
   writePluginInspectorInit,
   writeArtifacts,
   writeReport,
@@ -101,14 +104,19 @@ async function runReport(command, commandArgs) {
 
 async function runCi(commandArgs) {
   const configPath = readFlag(commandArgs, "--config");
+  const pluginRoot = readFlag(commandArgs, "--plugin-root") ?? readFlag(commandArgs, "--root");
   const outDir = readFlag(commandArgs, "--out") ?? "reports";
+  const openclawPath = commandArgs.includes("--no-openclaw") ? false : readFlag(commandArgs, "--openclaw");
   const json = commandArgs.includes("--json");
-  const config = await loadInspectorConfig(configPath);
-  const report = await inspectFixtureSet(config);
-  await writeReport(report, { outDir });
+  const { report, reportDir } = await runCiCompatibilityReport({
+    configPath,
+    openclawPath,
+    outDir,
+    pluginRoot,
+  });
 
   const summary = await buildCiSummary({
-    artifactBaseDir: outDir,
+    artifactBaseDir: reportDir,
     reportPaths: {
       compatibility: "plugin-inspector-report.json",
     },
@@ -117,8 +125,8 @@ async function runCi(commandArgs) {
     },
   });
   await writeCiSummary(summary, {
-    jsonPath: `${outDir}/plugin-inspector-ci-summary.json`,
-    markdownPath: `${outDir}/plugin-inspector-ci-summary.md`,
+    jsonPath: path.join(reportDir, "plugin-inspector-ci-summary.json"),
+    markdownPath: path.join(reportDir, "plugin-inspector-ci-summary.md"),
   });
 
   if (json) {
@@ -130,6 +138,24 @@ async function runCi(commandArgs) {
   if (summary.status !== "pass") {
     throw new Error("plugin-inspector ci summary failed");
   }
+}
+
+async function runCiCompatibilityReport({ configPath, openclawPath, outDir, pluginRoot }) {
+  if (configPath) {
+    const config = await loadInspectorConfig(configPath, { cwd: pluginRoot });
+    const report = await inspectCompatibilityFixtureSet(config, { openclawPath });
+    await writeCompatibilityReport(report, { cwd: config.rootDir, outDir });
+    return {
+      report,
+      reportDir: path.resolve(config.rootDir, outDir),
+    };
+  }
+
+  const { report } = await runPluginCheck({ pluginRoot, outDir, openclawPath });
+  return {
+    report,
+    reportDir: path.resolve(pluginRoot ?? process.cwd(), outDir),
+  };
 }
 
 async function runCapture(commandArgs) {
@@ -209,7 +235,7 @@ Usage:
   plugin-inspector init [--plugin-root <path>] [--config <path>] [--ci] [--package-manager npm|pnpm|yarn|bun] [--force]
   plugin-inspector report --config <path> [--out <dir>] [--check] [--json]
   plugin-inspector inspect --config <path> [--out <dir>] [--check] [--json]
-  plugin-inspector ci --config <path> [--out <dir>]
+  plugin-inspector ci [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path>] [--no-openclaw] [--json]
   PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 plugin-inspector capture <entrypoint> [--mock-sdk|--real-sdk] [--plugin-root <path>] [--output <path>]
 
 Default check runs from the current plugin root and writes reports/ unless --out is set.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -116,13 +116,39 @@ test("check command can enable runtime capture from plugin config", async () => 
   assert.equal(capture.summary.registrationCount, 1);
 });
 
+test("ci command writes CI summary artifacts", async () => {
+  const rootDir = await createCliPluginRoot("plugin-inspector-cli-ci-");
+  const cliPath = path.resolve("src/cli.js");
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [cliPath, "ci", "--config", path.join(rootDir, "plugin-inspector.config.json"), "--out", "reports"],
+    {
+      cwd: rootDir,
+    },
+  );
+
+  const summary = JSON.parse(
+    await readFile(path.join(rootDir, "reports", "plugin-inspector-ci-summary.json"), "utf8"),
+  );
+  const markdown = await readFile(path.join(rootDir, "reports", "plugin-inspector-ci-summary.md"), "utf8");
+
+  assert.match(stdout, /Status: PASS/);
+  assert.match(stdout, /Artifacts: 1/);
+  assert.equal(summary.status, "pass");
+  assert.equal(summary.summary.breakages, 0);
+  assert.equal(summary.summary.issues, 0);
+  assert.equal(summary.artifacts.compatibility, "plugin-inspector-report.json");
+  assert.match(markdown, /# Plugin Inspector CI Summary/);
+});
+
 test("init command writes plugin config and CI workflow", async () => {
   const rootDir = await createCliPluginRoot("plugin-inspector-cli-init-");
   const cliPath = path.resolve("src/cli.js");
 
   const { stdout } = await execFileAsync(
     process.execPath,
-    [cliPath, "init", "--plugin-root", rootDir, "--ci", "--package-manager", "pnpm"],
+    [cliPath, "init", "--plugin-root", rootDir, "--ci", "--package-manager", "pnpm", "--force"],
   );
   const config = JSON.parse(await readFile(path.join(rootDir, "plugin-inspector.config.json"), "utf8"));
   const workflow = await readFile(path.join(rootDir, ".github", "workflows", "plugin-inspector.yml"), "utf8");
@@ -163,6 +189,11 @@ async function createCliPluginRoot(prefix) {
   await writeFile(
     path.join(rootDir, "src", "index.js"),
     'import { definePluginEntry } from "openclaw/plugin-sdk";\nexport default definePluginEntry((api) => api.registerTool({ name: "weather" }));\n',
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "plugin-inspector.config.json"),
+    `${JSON.stringify({ version: 1, plugin: { id: "weather", priority: "high", sourceRoot: "src" } }, null, 2)}\n`,
     "utf8",
   );
   return rootDir;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -122,12 +122,13 @@ test("ci command writes CI summary artifacts", async () => {
 
   const { stdout } = await execFileAsync(
     process.execPath,
-    [cliPath, "ci", "--config", path.join(rootDir, "plugin-inspector.config.json"), "--out", "reports"],
+    [cliPath, "ci", "--config", path.join(rootDir, "plugin-inspector.config.json"), "--out", "reports", "--no-openclaw"],
     {
       cwd: rootDir,
     },
   );
 
+  const report = JSON.parse(await readFile(path.join(rootDir, "reports", "plugin-inspector-report.json"), "utf8"));
   const summary = JSON.parse(
     await readFile(path.join(rootDir, "reports", "plugin-inspector-ci-summary.json"), "utf8"),
   );
@@ -135,9 +136,11 @@ test("ci command writes CI summary artifacts", async () => {
 
   assert.match(stdout, /Status: PASS/);
   assert.match(stdout, /Artifacts: 1/);
+  assert.equal(report.targetOpenClaw.status, "disabled");
+  assert.ok(Array.isArray(report.issues));
   assert.equal(summary.status, "pass");
   assert.equal(summary.summary.breakages, 0);
-  assert.equal(summary.summary.issues, 0);
+  assert.equal(summary.summary.issues, report.summary.issueCount);
   assert.equal(summary.artifacts.compatibility, "plugin-inspector-report.json");
   assert.match(markdown, /# Plugin Inspector CI Summary/);
 });


### PR DESCRIPTION
## Summary

Fix the `plugin-inspector ci` command so it writes CI summary artifacts instead of behaving like `report`.

## What changed

- route `ci` to its own CLI handler instead of the report handler
- build and write `plugin-inspector-ci-summary.json` and `plugin-inspector-ci-summary.md`
- keep compatibility report generation in the `ci` flow so the summary has current input data
- add a CLI test that verifies `ci` writes CI summary artifacts

## Why

The CLI help advertises a dedicated `ci` command, but the implementation was wired through `runReport()`. In practice that meant `plugin-inspector ci` only emitted the standard report artifacts and never produced the CI summary artifacts the command name implies.

## Verification

- `npm run check`

Result:
- tests passing: 100/100
- `npm pack --dry-run` passing
