### PR TITLE
fix(ci-summary): detect runtime capture artifact by default

### DIFF
--- a/src/ci-summary.js
+++ b/src/ci-summary.js
@@ -5,7 +5,7 @@ import { readOptionalJsonFile } from "./json-file.js";
 
 export const defaultCiReportPaths = {
   compatibility: "reports/plugin-inspector-report.json",
-  capture: "reports/plugin-inspector-capture.json",
+  capture: "reports/plugin-inspector-runtime-capture.json",
   synthetic: "reports/plugin-inspector-synthetic-probes.json",
   coldImport: "reports/plugin-inspector-cold-import.json",
   workspace: "reports/plugin-inspector-workspace-plan.json",

--- a/test/ci-summary.test.js
+++ b/test/ci-summary.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -121,6 +121,27 @@ test("ci summary status fails on blocking report classes", () => {
   assert.equal(deriveCiStatus({ profileDiff: { summary: { failCount: 1 } } }), "fail");
   assert.equal(deriveCiStatus({ execution: { summary: { failCount: 1 } } }), "fail");
   assert.equal(deriveCiStatus({}), "pass");
+});
+
+test("ci summary discovers runtime capture artifacts from default paths", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-ci-summary-runtime-capture-"));
+  const reportsDir = path.join(dir, "reports");
+  await mkdir(reportsDir, { recursive: true });
+  await writeFile(
+    path.join(reportsDir, "plugin-inspector-report.json"),
+    `${JSON.stringify({ summary: { breakageCount: 0, warningCount: 0, suggestionCount: 0, issueCount: 0, p0IssueCount: 0, p1IssueCount: 0, liveIssueCount: 0, liveP0IssueCount: 0, compatGapCount: 0, deprecationWarningCount: 0, inspectorGapCount: 0, upstreamIssueCount: 0 }, issues: [] }, null, 2)}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(reportsDir, "plugin-inspector-runtime-capture.json"),
+    `${JSON.stringify({ summary: { targetCount: 1, capturedCount: 1, skippedCount: 0, failedCount: 0, registrationCount: 2, hookCount: 0 } }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const summary = await buildCiSummary({ reportsDir, artifactBaseDir: dir });
+
+  assert.equal(summary.artifacts.compatibility, "reports/plugin-inspector-report.json");
+  assert.equal(summary.artifacts.capture, "reports/plugin-inspector-runtime-capture.json");
 });
 
 test("ci summary writer emits JSON and Markdown artifacts", async () => {


### PR DESCRIPTION
## Summary

Fix CI summary artifact discovery so it detects the default runtime capture artifact path.

## What changed

- update the default CI summary capture artifact path to `reports/plugin-inspector-runtime-capture.json`
- add a regression test that verifies CI summary discovery picks up the runtime capture artifact from default paths

## Why

The CI summary default artifact map looked for `reports/plugin-inspector-capture.json`, but runtime capture writes `reports/plugin-inspector-runtime-capture.json`. That mismatch caused CI summaries to silently miss runtime capture artifacts unless callers overrode the path manually.

## Verification

- `npm run check`

Result:
- tests passing: 100/100
- `npm pack --dry-run` passing
