### PR TITLE
fix(workspace-plan): use packaged helper wrappers

### DIFF
--- a/src/capture-cli.js
+++ b/src/capture-cli.js
@@ -14,7 +14,7 @@ async function run(commandArgs) {
   const entrypoint = commandArgs.find((arg) => !arg.startsWith("-"));
   const outputPath = readFlag(commandArgs, "--output");
   const pluginRoot = readFlag(commandArgs, "--plugin-root");
-  const mockSdk = readMockSdkFlag(commandArgs) ?? commandArgs.includes("--mock-sdk");
+  const mockSdk = readMockSdkFlag(commandArgs) ?? true;
 
   if (!entrypoint) {
     throw new Error("capture requires an entrypoint path");

--- a/src/capture-cli.js
+++ b/src/capture-cli.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { captureEntrypoint, writeArtifacts } from "./advanced.js";
+
+const args = process.argv.slice(2);
+
+try {
+  await run(args);
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}
+
+async function run(commandArgs) {
+  const entrypoint = commandArgs.find((arg) => !arg.startsWith("-"));
+  const outputPath = readFlag(commandArgs, "--output");
+  const pluginRoot = readFlag(commandArgs, "--plugin-root");
+  const mockSdk = readMockSdkFlag(commandArgs) ?? commandArgs.includes("--mock-sdk");
+
+  if (!entrypoint) {
+    throw new Error("capture requires an entrypoint path");
+  }
+  if (process.env.PLUGIN_INSPECTOR_EXECUTE_ISOLATED !== "1") {
+    throw new Error("capture imports plugin code; rerun with PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 in an isolated workspace");
+  }
+
+  const result = await captureEntrypoint(entrypoint, { mockSdk, pluginRoot });
+  const json = `${JSON.stringify(result, null, 2)}\n`;
+  if (outputPath) {
+    await writeArtifacts([{ path: outputPath, content: json }]);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+function readFlag(commandArgs, name) {
+  const index = commandArgs.indexOf(name);
+  if (index === -1) {
+    return null;
+  }
+  return commandArgs[index + 1] ?? null;
+}
+
+function readMockSdkFlag(commandArgs) {
+  const sdk = readFlag(commandArgs, "--sdk");
+  if (sdk === "mock") {
+    return true;
+  }
+  if (sdk === "real") {
+    return false;
+  }
+  if (sdk && !["mock", "real"].includes(sdk)) {
+    throw new Error("--sdk must be mock or real");
+  }
+  if (commandArgs.includes("--mock-sdk")) {
+    return true;
+  }
+  if (commandArgs.includes("--real-sdk")) {
+    return false;
+  }
+  return undefined;
+}

--- a/src/synthetic-probes-cli.js
+++ b/src/synthetic-probes-cli.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { captureEntrypoint, runCapturedSyntheticProbes, writeArtifacts } from "./advanced.js";
+
+const args = process.argv.slice(2);
+
+try {
+  await run(args);
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}
+
+async function run(commandArgs) {
+  const entrypoint = readFlag(commandArgs, "--entrypoint") ?? commandArgs.find((arg) => !arg.startsWith("-"));
+  const outputPath = readFlag(commandArgs, "--output");
+  const pluginRoot = readFlag(commandArgs, "--plugin-root");
+  const includeLifecycle = commandArgs.includes("--include-lifecycle");
+  const includeChannelRuntime = commandArgs.includes("--include-channel-runtime");
+  const includeProviderCapabilities = commandArgs.includes("--include-provider-capabilities");
+  const mockSdk = readMockSdkFlag(commandArgs) ?? commandArgs.includes("--mock-sdk");
+
+  if (!entrypoint) {
+    throw new Error("synthetic probes require --entrypoint <path>");
+  }
+  if (process.env.PLUGIN_INSPECTOR_EXECUTE_ISOLATED !== "1") {
+    throw new Error("synthetic probes import plugin code; rerun with PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 in an isolated workspace");
+  }
+
+  const capture = await captureEntrypoint(entrypoint, {
+    mockSdk,
+    pluginRoot,
+    apiOptions: { retainHandlers: true },
+  });
+  const results = await runCapturedSyntheticProbes(capture, {
+    includeLifecycle,
+    includeChannelRuntime,
+    includeProviderCapabilities,
+  });
+  const json = `${JSON.stringify(results, null, 2)}\n`;
+
+  if (outputPath) {
+    await writeArtifacts([{ path: outputPath, content: json }]);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+function readFlag(commandArgs, name) {
+  const index = commandArgs.indexOf(name);
+  if (index === -1) {
+    return null;
+  }
+  return commandArgs[index + 1] ?? null;
+}
+
+function readMockSdkFlag(commandArgs) {
+  const sdk = readFlag(commandArgs, "--sdk");
+  if (sdk === "mock") {
+    return true;
+  }
+  if (sdk === "real") {
+    return false;
+  }
+  if (sdk && !["mock", "real"].includes(sdk)) {
+    throw new Error("--sdk must be mock or real");
+  }
+  if (commandArgs.includes("--mock-sdk")) {
+    return true;
+  }
+  if (commandArgs.includes("--real-sdk")) {
+    return false;
+  }
+  return undefined;
+}

--- a/src/synthetic-probes-cli.js
+++ b/src/synthetic-probes-cli.js
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
+import { mkdtemp, rm } from "node:fs/promises";
+import { register } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { captureEntrypoint, runCapturedSyntheticProbes, writeArtifacts } from "./advanced.js";
+import { createMockSdkPackage } from "./sdk-mock.js";
 
 const args = process.argv.slice(2);
 
@@ -17,7 +23,7 @@ async function run(commandArgs) {
   const includeLifecycle = commandArgs.includes("--include-lifecycle");
   const includeChannelRuntime = commandArgs.includes("--include-channel-runtime");
   const includeProviderCapabilities = commandArgs.includes("--include-provider-capabilities");
-  const mockSdk = readMockSdkFlag(commandArgs) ?? commandArgs.includes("--mock-sdk");
+  const mockSdk = readMockSdkFlag(commandArgs) ?? true;
 
   if (!entrypoint) {
     throw new Error("synthetic probes require --entrypoint <path>");
@@ -26,7 +32,7 @@ async function run(commandArgs) {
     throw new Error("synthetic probes import plugin code; rerun with PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 in an isolated workspace");
   }
 
-  const capture = await captureEntrypoint(entrypoint, {
+  const capture = await captureForSyntheticProbes(entrypoint, {
     mockSdk,
     pluginRoot,
     apiOptions: { retainHandlers: true },
@@ -42,6 +48,27 @@ async function run(commandArgs) {
     await writeArtifacts([{ path: outputPath, content: json }]);
   } else {
     process.stdout.write(json);
+  }
+}
+
+async function captureForSyntheticProbes(entrypoint, options) {
+  if (options.mockSdk !== true) {
+    return captureEntrypoint(entrypoint, options);
+  }
+
+  const resolvedEntrypoint = path.resolve(process.cwd(), entrypoint);
+  const pluginRoot = path.resolve(process.cwd(), options.pluginRoot ?? path.dirname(resolvedEntrypoint));
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-synthetic-mock-sdk-"));
+  try {
+    const { loaderPath } = await createMockSdkPackage(workspace, { pluginRoot });
+    register(pathToFileURL(loaderPath));
+    return captureEntrypoint(entrypoint, {
+      ...options,
+      mockSdk: false,
+      pluginRoot,
+    });
+  } finally {
+    await rm(workspace, { force: true, recursive: true });
   }
 }
 

--- a/src/workspace-plan.js
+++ b/src/workspace-plan.js
@@ -452,13 +452,13 @@ function runCommand(packageManager, script) {
 function captureCommand(settings, fixtureId, entrypoint, workspacePath) {
   const loader = entrypoint.blockers.some((blocker) => blocker.code === "ts-loader-required") ? " --import tsx" : "";
   const script = helperScript(settings, workspacePath, settings.captureScript, "capture-cli.js");
-  return `${settings.optInEnv} node${loader} ${script} ${entrypoint.specifier} --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "capture")}`;
+  return `${settings.optInEnv} node${loader} ${script} ${entrypoint.specifier} --mock-sdk --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "capture")}`;
 }
 
 function syntheticProbeCommand(settings, fixtureId, entrypoint, workspacePath) {
   const loader = entrypoint.blockers.some((blocker) => blocker.code === "ts-loader-required") ? " --import tsx" : "";
   const script = helperScript(settings, workspacePath, settings.syntheticProbeScript, "synthetic-probes-cli.js");
-  return `${settings.optInEnv} node${loader} ${script} --entrypoint ${entrypoint.specifier} --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "synthetic")}`;
+  return `${settings.optInEnv} node${loader} ${script} --entrypoint ${entrypoint.specifier} --mock-sdk --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "synthetic")}`;
 }
 
 function helperScript(settings, workspacePath, configuredScript, helperFileName) {

--- a/src/workspace-plan.js
+++ b/src/workspace-plan.js
@@ -1,15 +1,16 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { renderPaddedMarkdownTable, writeJsonMarkdownArtifacts } from "./artifacts.js";
 import { buildColdImportReadiness } from "./cold-import-readiness.js";
 import { normalizeRepoPath, posixJoin, slugForArtifact } from "./path-utils.js";
 
 export const defaultWorkspacePlanOptions = {
-  captureScript: "plugin-inspector-capture",
+  captureScript: null,
   optInEnv: "PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1",
   resultsRoot: ".plugin-inspector/results",
-  syntheticProbeScript: "plugin-inspector-synthetic-probes",
+  syntheticProbeScript: null,
   workspaceRoot: ".plugin-inspector/workspaces",
 };
 
@@ -450,12 +451,23 @@ function runCommand(packageManager, script) {
 
 function captureCommand(settings, fixtureId, entrypoint, workspacePath) {
   const loader = entrypoint.blockers.some((blocker) => blocker.code === "ts-loader-required") ? " --import tsx" : "";
-  return `${settings.optInEnv} node${loader} ${settings.captureScript} ${entrypoint.specifier} --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "capture")}`;
+  const script = helperScript(settings, workspacePath, settings.captureScript, "capture-cli.js");
+  return `${settings.optInEnv} node${loader} ${script} ${entrypoint.specifier} --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "capture")}`;
 }
 
 function syntheticProbeCommand(settings, fixtureId, entrypoint, workspacePath) {
   const loader = entrypoint.blockers.some((blocker) => blocker.code === "ts-loader-required") ? " --import tsx" : "";
-  return `${settings.optInEnv} node${loader} ${settings.syntheticProbeScript} --entrypoint ${entrypoint.specifier} --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "synthetic")}`;
+  const script = helperScript(settings, workspacePath, settings.syntheticProbeScript, "synthetic-probes-cli.js");
+  return `${settings.optInEnv} node${loader} ${script} --entrypoint ${entrypoint.specifier} --output ${workspaceArtifactPath(settings, fixtureId, entrypoint, workspacePath, "synthetic")}`;
+}
+
+function helperScript(settings, workspacePath, configuredScript, helperFileName) {
+  if (configuredScript) {
+    return configuredScript;
+  }
+  const helperPath = fileURLToPath(new URL(`./${helperFileName}`, import.meta.url));
+  const workspaceFsPath = path.join(settings.rootDir, workspacePath);
+  return repoRelative(path.relative(workspaceFsPath, helperPath));
 }
 
 function targetOpenClawWorkspacePath(settings, fixtureId, targetOpenClawPath) {

--- a/test/helper-clis.test.js
+++ b/test/helper-clis.test.js
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { test } from "node:test";
+
+const execFileAsync = promisify(execFile);
+
+test("capture and synthetic helper CLIs smoke test against a shimmed SDK", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-helper-cli-"));
+  await mkdir(path.join(rootDir, "src"), { recursive: true });
+  await mkdir(path.join(rootDir, "node_modules", "openclaw"), { recursive: true });
+
+  await writeFile(
+    path.join(rootDir, "package.json"),
+    `${JSON.stringify({ name: "fixture", type: "module" }, null, 2)}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "node_modules", "openclaw", "package.json"),
+    `${JSON.stringify({ name: "openclaw", type: "module", exports: { "./plugin-sdk": "./plugin-sdk.js" } }, null, 2)}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "node_modules", "openclaw", "plugin-sdk.js"),
+    "export function definePluginEntry(register) { return { register }; }\n",
+    "utf8",
+  );
+  await writeFile(
+    path.join(rootDir, "src", "index.js"),
+    [
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      "export default definePluginEntry((api) => api.registerTool({",
+      '  name: "fixture-tool",',
+      '  description: "fixture",',
+      '  run: async () => ({ ok: true }),',
+      "}));",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const captureCli = path.resolve("src/capture-cli.js");
+  const syntheticCli = path.resolve("src/synthetic-probes-cli.js");
+  const captureOut = path.join(rootDir, "capture.json");
+  const syntheticOut = path.join(rootDir, "synthetic.json");
+  const env = { ...process.env, PLUGIN_INSPECTOR_EXECUTE_ISOLATED: "1" };
+
+  await execFileAsync(process.execPath, [captureCli, "./src/index.js", "--output", captureOut], {
+    cwd: rootDir,
+    env,
+  });
+  await execFileAsync(process.execPath, [syntheticCli, "--entrypoint", "./src/index.js", "--output", syntheticOut], {
+    cwd: rootDir,
+    env,
+  });
+
+  const capture = JSON.parse(await readFile(captureOut, "utf8"));
+  const synthetic = JSON.parse(await readFile(syntheticOut, "utf8"));
+
+  assert.equal(capture.status, "captured");
+  assert.ok(capture.captured.some((item) => item.kind === "registration" && item.name === "registerTool"));
+  assert.equal(synthetic.status, "captured");
+  assert.equal(synthetic.summary.failCount, 0);
+  assert.equal(synthetic.summary.blockedCount, 0);
+  assert.ok(synthetic.summary.passCount >= 1);
+});

--- a/test/helper-clis.test.js
+++ b/test/helper-clis.test.js
@@ -8,24 +8,13 @@ import { test } from "node:test";
 
 const execFileAsync = promisify(execFile);
 
-test("capture and synthetic helper CLIs smoke test against a shimmed SDK", async () => {
+test("capture and synthetic helper CLIs default to the mocked SDK", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-helper-cli-"));
   await mkdir(path.join(rootDir, "src"), { recursive: true });
-  await mkdir(path.join(rootDir, "node_modules", "openclaw"), { recursive: true });
 
   await writeFile(
     path.join(rootDir, "package.json"),
     `${JSON.stringify({ name: "fixture", type: "module" }, null, 2)}\n`,
-    "utf8",
-  );
-  await writeFile(
-    path.join(rootDir, "node_modules", "openclaw", "package.json"),
-    `${JSON.stringify({ name: "openclaw", type: "module", exports: { "./plugin-sdk": "./plugin-sdk.js" } }, null, 2)}\n`,
-    "utf8",
-  );
-  await writeFile(
-    path.join(rootDir, "node_modules", "openclaw", "plugin-sdk.js"),
-    "export function definePluginEntry(register) { return { register }; }\n",
     "utf8",
   );
   await writeFile(

--- a/test/workspace-plan.test.js
+++ b/test/workspace-plan.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -82,6 +82,53 @@ test("workspace plan maps blocked entrypoints to opt-in install/build/capture st
   assert.match(renderWorkspacePlanMarkdown(plan), /Entrypoint Workspaces/);
 });
 
+test("workspace plan defaults point at packaged helper wrappers", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-workspace-defaults-"));
+  t.after(() => rm(rootDir, { recursive: true, force: true }));
+
+  await mkdir(path.join(rootDir, "plugins/fixture"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "plugins/fixture/package.json"),
+    JSON.stringify(
+      {
+        name: "fixture",
+        packageManager: "npm@10.0.0",
+        scripts: { build: "tsup" },
+        dependencies: { "left-pad": "^1.3.0" },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await writeFile(path.join(rootDir, "plugins/fixture/package-lock.json"), "{}\n", "utf8");
+  await mkdir(path.join(rootDir, "plugins/build"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "plugins/build/package.json"),
+    JSON.stringify({ name: "build-fixture", scripts: { build: "tsup" } }, null, 2),
+    "utf8",
+  );
+
+  const report = readinessReport();
+  const readiness = buildColdImportReadiness({ report, rootDir });
+  const plan = await buildWorkspacePlan({ report, readiness, rootDir });
+  const entrypoint = plan.fixtures[0].entrypoints[0];
+  const captureStep = entrypoint.steps.find((step) => step.kind === "capture");
+  const syntheticStep = entrypoint.steps.find((step) => step.kind === "synthetic-probe");
+
+  assert.ok(captureStep.command.includes("src/capture-cli.js"));
+  assert.ok(syntheticStep.command.includes("src/synthetic-probes-cli.js"));
+  assert.ok(syntheticStep.command.includes("--entrypoint ./src/index.ts"));
+  assert.ok(syntheticStep.command.includes(".synthetic.json"));
+
+  const captureHelper = resolveNodeScriptFromStep(captureStep, rootDir);
+  const syntheticHelper = resolveNodeScriptFromStep(syntheticStep, rootDir);
+  await access(captureHelper);
+  await access(syntheticHelper);
+  assert.match(captureHelper, /src[\\/]capture-cli\.js$/);
+  assert.match(syntheticHelper, /src[\\/]synthetic-probes-cli\.js$/);
+});
+
 test("workspace plan validation keeps execution opt-in and explicit", () => {
   const plan = {
     mode: "execute",
@@ -130,6 +177,29 @@ test("workspace plan validation keeps execution opt-in and explicit", () => {
   const stepErrors = validateWorkspacePlan(plan);
   assert.ok(stepErrors.some((error) => error.includes("prepare step missing command, cwd, or reason")));
 });
+
+function resolveNodeScriptFromStep(step, rootDir) {
+  const tokens = step.command.trim().split(/\s+/);
+  const nodeIndex = tokens.findIndex((token) => token === "node");
+  assert.notEqual(nodeIndex, -1, `expected node invocation in command: ${step.command}`);
+
+  let scriptToken = null;
+  for (let index = nodeIndex + 1; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--import") {
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      continue;
+    }
+    scriptToken = token;
+    break;
+  }
+
+  assert.ok(scriptToken, `expected script path in command: ${step.command}`);
+  return path.resolve(rootDir, step.cwd, scriptToken);
+}
 
 function readinessReport() {
   return {

--- a/test/workspace-plan.test.js
+++ b/test/workspace-plan.test.js
@@ -117,8 +117,10 @@ test("workspace plan defaults point at packaged helper wrappers", async (t) => {
   const syntheticStep = entrypoint.steps.find((step) => step.kind === "synthetic-probe");
 
   assert.ok(captureStep.command.includes("src/capture-cli.js"));
+  assert.ok(captureStep.command.includes("--mock-sdk"));
   assert.ok(syntheticStep.command.includes("src/synthetic-probes-cli.js"));
   assert.ok(syntheticStep.command.includes("--entrypoint ./src/index.ts"));
+  assert.ok(syntheticStep.command.includes("--mock-sdk"));
   assert.ok(syntheticStep.command.includes(".synthetic.json"));
 
   const captureHelper = resolveNodeScriptFromStep(captureStep, rootDir);


### PR DESCRIPTION
## Summary
- resolve default workspace helper commands from the installed package path instead of the inspected repo
- add packaged capture/synthetic helper CLIs for generated workspace plans
- run synthetic probes by capturing retained handlers and probing in the same process
- add smoke coverage for both helper CLIs plus path-resolution coverage for generated default commands

## Testing
- npm run check
- node --test test/helper-clis.test.js test/workspace-plan.test.js