### PR TITLE
fix(contract): accept compat-gap coverage records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Stop classifying package source entrypoints as missing when the published package provides built runtime entrypoints, and collapse SDK alias findings into a single compat-gap row.
+- Treat compat-gap issues as reconciled contract coverage for their own compatibility record.
 
 ## 0.3.10 - 2026-05-03
 

--- a/src/contract-coverage.js
+++ b/src/contract-coverage.js
@@ -157,10 +157,15 @@ function requireCompatRecordReconciliation(report, errors) {
       .filter((finding) => finding.code === "missing-compat-record")
       .map((finding) => `${finding.fixture}:${finding.compatRecord}`),
   );
+  const compatGapRecords = new Set(
+    report.issues
+      .filter((issue) => issue.issueClass === "compat-gap" && issue.compatRecord)
+      .map((issue) => `${issue.fixture}:${issue.compatRecord}`),
+  );
 
   for (const finding of [...report.warnings, ...report.suggestions].filter((item) => item.compatRecord)) {
     const key = `${finding.fixture}:${finding.compatRecord}`;
-    if (!presentRecords.has(key) && !missingRecords.has(key)) {
+    if (!presentRecords.has(key) && !missingRecords.has(key) && !compatGapRecords.has(key)) {
       errors.push(`${finding.fixture}: compat record ${finding.compatRecord} was not reconciled`);
     }
   }

--- a/test/contract-coverage.test.js
+++ b/test/contract-coverage.test.js
@@ -165,4 +165,20 @@ test("contract coverage requires compat record reconciliation evidence", () => {
     compatRecord: "fixture.provider-auth-env-vars",
   });
   assert.deepEqual(validateContractCoverage(report), []);
+
+  report.logs = [];
+  report.issues.push({
+    id: "PLUGIN-COMPAT",
+    fixture: "fixture",
+    severity: "P1",
+    issueClass: "compat-gap",
+    code: "provider-auth-env-vars",
+    evidence: ["fixture"],
+    compatRecord: "fixture.provider-auth-env-vars",
+  });
+  report.contractProbes.push({
+    fixture: "fixture",
+    id: "compat.provider-auth-env-vars:fixture",
+  });
+  assert.deepEqual(validateContractCoverage(report), []);
 });


### PR DESCRIPTION
## Summary
- treat compat-gap issues as reconciliation evidence for their own compat records
- add coverage for the contract validator path Crabpot hits after sdk-export findings are collapsed

## Verification
- npm test
- npm run check

Follow-up to https://github.com/openclaw/plugin-inspector/pull/18