### PR TITLE
fix(reports): cover synthetic hook probe results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Stop classifying package source entrypoints as missing when the published package provides built runtime entrypoints, and collapse SDK alias findings into a single compat-gap row.
 - Treat compat-gap issues as reconciled contract coverage for their own compatibility record.
+- Count passed synthetic hook probes as runtime coverage so conversation-access and `before_tool_call` inspector gaps close when probe artifacts prove them.
 
 ## 0.3.10 - 2026-05-03
 

--- a/src/execution-results.js
+++ b/src/execution-results.js
@@ -204,6 +204,7 @@ function summarizeArtifact({ artifactPath, parsed, rootDir }) {
         : "capture";
   const fixture = normalizedArtifactPath.split("/").at(-2) ?? "unknown";
   if (kind === "synthetic") {
+    const passed = (parsed.results ?? []).filter((result) => result.status === "pass");
     return {
       artifactPath: normalizedArtifactPath,
       fixture,
@@ -211,6 +212,8 @@ function summarizeArtifact({ artifactPath, parsed, rootDir }) {
       entrypoint: scrubPath(parsed.entrypoint, { rootDir }),
       status: parsed.status,
       summary: parsed.summary,
+      captured: passed.map(syntheticRuntimeCaptureKey).filter(Boolean),
+      passed,
       failures: (parsed.results ?? []).filter((result) => result.status === "fail"),
       blocked: (parsed.results ?? []).filter((result) => result.status === "blocked"),
     };
@@ -259,6 +262,13 @@ function summarizeArtifactResult(artifact) {
     return `${artifact.summary.passCount} pass / ${artifact.summary.failCount} fail / ${artifact.summary.blockedCount} blocked`;
   }
   return `${artifact.capturedCount} captured`;
+}
+
+function syntheticRuntimeCaptureKey(result) {
+  if (!result.kind || !result.seam) {
+    return null;
+  }
+  return `${result.kind}:${result.seam}`;
 }
 
 function auditFindingCount(parsed) {

--- a/src/runtime-reconciliation.js
+++ b/src/runtime-reconciliation.js
@@ -28,7 +28,7 @@ export function applyRuntimeExecutionCoverage({ findings = [], executionResults 
 export function buildRuntimeExecutionCoverage(executionResults) {
   const fixtures = new Map();
   for (const artifact of executionResults?.artifacts ?? []) {
-    if (artifact.kind !== "capture") {
+    if (!["capture", "synthetic"].includes(artifact.kind)) {
       continue;
     }
 
@@ -83,6 +83,9 @@ function expectedRuntimeCaptureKeys(finding) {
   }
   if (finding.code === "conversation-access-hook") {
     return names.map((name) => `hook:${name}`);
+  }
+  if (finding.code === "before-tool-call-probe") {
+    return ["hook:before_tool_call"];
   }
   return [];
 }

--- a/test/execution-results.test.js
+++ b/test/execution-results.test.js
@@ -95,6 +95,8 @@ test("execution results summarize capture, synthetic, audit, and profile artifac
   assert.equal(report.summary.capturedRegistrationCount, 1);
   assert.equal(report.summary.passCount, 1);
   assert.equal(report.summary.blockedCount, 1);
+  assert.deepEqual(report.artifacts.find((artifact) => artifact.kind === "synthetic").captured, ["hook:before_tool_call"]);
+  assert.equal(report.artifacts.find((artifact) => artifact.kind === "synthetic").passed[0].seam, "before_tool_call");
   assert.equal(report.artifacts.find((artifact) => artifact.kind === "synthetic").blocked[0].seam, "registerChannel");
   assert.equal(report.artifacts.find((artifact) => artifact.kind === "audit").findingCount, 6);
   assert.match(markdown, /# Fixture Execution Results/);

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -387,8 +387,11 @@ test("compatibility report marks inspector gaps covered by runtime execution art
       {
         id: "fixture",
         status: "ok",
-        hooks: ["llm_input"],
-        hookDetails: [{ name: "llm_input", ref: "plugins/fixture/src/index.ts:1" }],
+        hooks: ["llm_input", "before_tool_call"],
+        hookDetails: [
+          { name: "llm_input", ref: "plugins/fixture/src/index.ts:1" },
+          { name: "before_tool_call", ref: "plugins/fixture/src/index.ts:5" },
+        ],
         registrations: ["registerTool", "registerService", "registerCommand"],
         registrationDetails: [
           { name: "registerTool", ref: "plugins/fixture/src/index.ts:2" },
@@ -405,7 +408,7 @@ test("compatibility report marks inspector gaps covered by runtime execution art
       status: "ok",
       compatRecords: [],
       compatRecordStatuses: {},
-      hookNames: ["llm_input"],
+      hookNames: ["llm_input", "before_tool_call"],
       apiRegistrars: ["registerTool", "registerService", "registerCommand"],
       capturedRegistrars: [],
       sdkExports: [],
@@ -425,6 +428,13 @@ test("compatibility report marks inspector gaps covered by runtime execution art
             "registration:registerService",
             "registration:registerCommand",
           ],
+        },
+        {
+          fixture: "fixture",
+          kind: "synthetic",
+          status: "pass",
+          artifactPath: ".crabpot/results/fixture/index.synthetic.json",
+          captured: ["hook:before_tool_call"],
         },
       ],
     },
@@ -455,13 +465,14 @@ test("compatibility report marks inspector gaps covered by runtime execution art
     .map((issue) => issue.code)
     .sort();
   assert.deepEqual(coveredCodes, [
+    "before-tool-call-probe",
     "conversation-access-hook",
     "registration-capture-gap",
     "runtime-tool-capture",
   ]);
-  assert.equal(report.summary.runtimeCoveredIssueCount, 3);
+  assert.equal(report.summary.runtimeCoveredIssueCount, 4);
   assert.equal(report.summary.openInspectorGapCount, 0);
-  assert.equal(report.summary.runtimeCoverageArtifactCount, 1);
+  assert.equal(report.summary.runtimeCoverageArtifactCount, 2);
 
   const registrationIssue = report.issues.find((issue) => issue.code === "registration-capture-gap");
   assert.deepEqual(registrationIssue.runtimeCoverage.captured, [


### PR DESCRIPTION
## Summary
- include passed synthetic probe rows as runtime coverage evidence in execution-result summaries
- let runtime reconciliation close `before-tool-call-probe` when `hook:before_tool_call` is proven
- keep failed or blocked synthetic probes non-covering

## Proof
- `npm run check`
- Crabpot source-mode smoke with local plugin-inspector source: `Status: PASS`
- Crabpot narrow fixture proof: `wecom before-tool-call-probe runtime-covered covered captured=hook:before_tool_call`

## Notes
- Existing Crabpot beta reports still need fresh workspace execution artifacts for all affected fixtures; this PR makes those artifacts count once generated.