### PR TITLE
fix(runtime): keep synthetic hook probes callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Stop classifying package source entrypoints as missing when the published package provides built runtime entrypoints, and collapse SDK alias findings into a single compat-gap row.
 - Treat compat-gap issues as reconciled contract coverage for their own compatibility record.
 - Count passed synthetic hook probes as runtime coverage so conversation-access and `before_tool_call` inspector gaps close when probe artifacts prove them.
+- Keep mock-SDK synthetic probes in-process so retained hook and registration handlers remain callable, and harden dynamic root SDK mock exports.
+- Synthesize nested manifest config samples for optional object settings with required inner shape.
+- Populate message and agent lifecycle synthetic hook payloads with the fields telemetry plugins commonly read.
+- Resolve plugin manifests from parent directories when runtime capture starts from built `dist` entrypoints.
 
 ## 0.3.10 - 2026-05-03
 

--- a/src/advanced.js
+++ b/src/advanced.js
@@ -194,6 +194,7 @@ export {
   writeRuntimeCaptureReport,
 } from "./runtime-capture-report.js";
 export { createMockSdkPackage } from "./sdk-mock.js";
+export { runEntrypointSyntheticProbes } from "./synthetic-entrypoint.js";
 export {
   buildSyntheticProbePlan,
   defaultSyntheticHookContexts,

--- a/src/capture-config.js
+++ b/src/capture-config.js
@@ -17,7 +17,10 @@ export async function captureApiOptionsForPlugin(apiOptions = {}, options = {}) 
 }
 
 async function readSamplePluginConfig(pluginRoot) {
-  const manifestPath = path.join(pluginRoot, "openclaw.plugin.json");
+  const manifestPath = await findNearestManifestPath(pluginRoot);
+  if (!manifestPath) {
+    return undefined;
+  }
   let manifest;
   try {
     manifest = JSON.parse(await readFile(manifestPath, "utf8"));
@@ -27,6 +30,23 @@ async function readSamplePluginConfig(pluginRoot) {
 
   const sample = sampleJsonSchema(manifest.configSchema, { key: "config" });
   return isPlainObject(sample) && Object.keys(sample).length > 0 ? sample : undefined;
+}
+
+async function findNearestManifestPath(pluginRoot) {
+  let current = path.resolve(pluginRoot);
+  while (true) {
+    const manifestPath = path.join(current, "openclaw.plugin.json");
+    try {
+      await readFile(manifestPath, "utf8");
+      return manifestPath;
+    } catch {}
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
 }
 
 function sampleJsonSchema(schema, context = {}) {
@@ -83,6 +103,16 @@ function sampleObjectSchema(schema) {
     }
   }
 
+  if (!hasNonBooleanSample(output, properties)) {
+    const key = preferredNestedConfigKey(properties);
+    if (key) {
+      const value = sampleJsonSchema(properties[key], { key });
+      if (value !== undefined) {
+        output[key] = value;
+      }
+    }
+  }
+
   if (Object.keys(output).length === 0 && Number(schema.minProperties ?? 0) > 0) {
     const key = preferredSamplePropertyKey(properties);
     if (key) {
@@ -94,6 +124,24 @@ function sampleObjectSchema(schema) {
   }
 
   return output;
+}
+
+function hasNonBooleanSample(output, properties) {
+  return Object.keys(output).some((key) => properties[key]?.type !== "boolean");
+}
+
+function preferredNestedConfigKey(properties) {
+  for (const key of ["embedding", "credentials", "auth", "provider", ...Object.keys(properties)]) {
+    const schema = properties[key];
+    if (!isPlainObject(schema)) {
+      continue;
+    }
+    const required = Array.isArray(schema.required) ? schema.required : [];
+    if ((schema.type === "object" || schema.properties) && (Number(schema.minProperties ?? 0) > 0 || required.length > 0)) {
+      return key;
+    }
+  }
+  return null;
 }
 
 function preferredSamplePropertyKey(properties) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import * as refDiffApi from "./ref-diff.js";
 import * as reportApi from "./report.js";
 import * as runtimeProfileApi from "./runtime-profile.js";
 import * as runtimeReconciliationApi from "./runtime-reconciliation.js";
+import * as syntheticEntrypointApi from "./synthetic-entrypoint.js";
 import * as syntheticProbeSuiteApi from "./synthetic-probe-suite.js";
 import * as syntheticProbesApi from "./synthetic-probes.js";
 
@@ -123,6 +124,7 @@ export const synthetic = Object.freeze({
   renderPlan: syntheticProbesApi.renderSyntheticProbeMarkdown,
   validatePlan: syntheticProbesApi.validateSyntheticProbePlan,
   runCaptured: syntheticProbesApi.runCapturedSyntheticProbes,
+  runEntrypoint: syntheticEntrypointApi.runEntrypointSyntheticProbes,
   registrationExecutionProfiles: syntheticProbesApi.syntheticRegistrationExecutionProfiles,
   defaultHookEvents: syntheticProbesApi.defaultSyntheticHookEvents,
   defaultHookContexts: syntheticProbesApi.defaultSyntheticHookContexts,
@@ -234,6 +236,7 @@ export {
   applyRuntimeExecutionCoverage,
   buildRuntimeExecutionCoverage,
 } from "./runtime-reconciliation.js";
+export { runEntrypointSyntheticProbes } from "./synthetic-entrypoint.js";
 export { buildSyntheticProbePlanFromReport } from "./synthetic-probe-suite.js";
 export {
   buildSyntheticProbePlan,

--- a/src/sdk-mock.js
+++ b/src/sdk-mock.js
@@ -377,6 +377,9 @@ function parseModuleImports(text) {
   ];
   for (const pattern of patterns) {
     for (const match of text.matchAll(pattern)) {
+      if (isTypeOnlyImportOrExport(match[0], match[1] ?? "")) {
+        continue;
+      }
       const specifier = match[2];
       if (specifier) {
         entries.push({ specifier, names: parseNamedImports(match[1] ?? "") });
@@ -387,6 +390,10 @@ function parseModuleImports(text) {
     entries.push({ specifier: match[1], names: new Set() });
   }
   return entries;
+}
+
+function isTypeOnlyImportOrExport(statement, clause) {
+  return /^\s*import\s+type\b/u.test(statement) || /^\s*export\s+type\b/u.test(statement) || /^\s*type\b/u.test(clause);
 }
 
 function parseNamedImports(clause) {
@@ -1665,11 +1672,53 @@ export const OPENAI_RESPONSES_STREAM_HOOKS = buildProviderStreamFamilyHooks("ope
 export const OPENROUTER_THINKING_STREAM_HOOKS = buildProviderStreamFamilyHooks("openrouter-thinking");
 export const TOOL_STREAM_DEFAULT_ON_HOOKS = buildProviderStreamFamilyHooks("tool-stream-default");
 export const pluginSdkMock = true;
+${dynamicExportNames.length > 0 ? mockValueRuntimeSource() : ""}
 ${dynamicExportNames.map(genericExportStatement).join("\n")}
 
 export default {
 ${[...exportNames].map((name) => `  ${name},`).join("\n")}
 };
+  `;
+}
+
+function mockValueRuntimeSource() {
+  return `function createMockValue(name) {
+  function fn(...args) {
+    if (name === "resolvePreferredOpenClawTmpDir") {
+      return process.env.TMPDIR || "/tmp";
+    }
+    if (name.startsWith("normalize")) {
+      return typeof args[0] === "string" ? args[0] : "";
+    }
+    if (name === "jsonResult") {
+      return { type: "json", value: args[0] };
+    }
+    if (name === "readStringParam") {
+      return typeof args[0] === "string" ? args[0] : "";
+    }
+    return createMockValue(name);
+  }
+  return new Proxy(fn, {
+    get(_target, property) {
+      if (property === "then") {
+        return undefined;
+      }
+      if (property === Symbol.toPrimitive) {
+        return () => name;
+      }
+      if (property === "toString") {
+        return () => name;
+      }
+      if (property === "valueOf") {
+        return () => name;
+      }
+      return createMockValue(\`\${name}.\${String(property)}\`);
+    },
+    construct() {
+      return createMockValue(name);
+    },
+  });
+}
 `;
 }
 

--- a/src/synthetic-entrypoint.js
+++ b/src/synthetic-entrypoint.js
@@ -1,0 +1,47 @@
+import { rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { register } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { captureEntrypoint } from "./inspector.js";
+import { createMockSdkPackage } from "./sdk-mock.js";
+import { runCapturedSyntheticProbes } from "./synthetic-probes.js";
+
+export async function runEntrypointSyntheticProbes(entrypoint, options = {}) {
+  const capture = await captureEntrypointForSyntheticProbes(entrypoint, {
+    ...options,
+    apiOptions: {
+      ...(options.apiOptions ?? {}),
+      retainHandlers: true,
+    },
+  });
+  return runCapturedSyntheticProbes(capture, options);
+}
+
+async function captureEntrypointForSyntheticProbes(entrypoint, options) {
+  if (options.mockSdk !== true) {
+    return captureEntrypoint(entrypoint, options);
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const resolvedEntrypoint = path.resolve(cwd, entrypoint);
+  const pluginRoot = path.resolve(cwd, options.pluginRoot ?? path.dirname(resolvedEntrypoint));
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-synthetic-mock-sdk-"));
+  cleanupTempDirOnExit(workspace);
+  const { loaderPath } = await createMockSdkPackage(workspace, { pluginRoot });
+  register(pathToFileURL(loaderPath));
+
+  return captureEntrypoint(entrypoint, {
+    ...options,
+    cwd,
+    mockSdk: false,
+    pluginRoot,
+  });
+}
+
+function cleanupTempDirOnExit(dir) {
+  process.once("exit", () => {
+    rmSync(dir, { force: true, recursive: true });
+  });
+}

--- a/src/synthetic-probes-cli.js
+++ b/src/synthetic-probes-cli.js
@@ -1,12 +1,5 @@
 #!/usr/bin/env node
-import { rmSync } from "node:fs";
-import { mkdtemp } from "node:fs/promises";
-import { register } from "node:module";
-import os from "node:os";
-import path from "node:path";
-import { pathToFileURL } from "node:url";
-import { captureEntrypoint, runCapturedSyntheticProbes, writeArtifacts } from "./advanced.js";
-import { createMockSdkPackage } from "./sdk-mock.js";
+import { runEntrypointSyntheticProbes, writeArtifacts } from "./advanced.js";
 
 const args = process.argv.slice(2);
 
@@ -33,12 +26,10 @@ async function run(commandArgs) {
     throw new Error("synthetic probes import plugin code; rerun with PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 in an isolated workspace");
   }
 
-  const capture = await captureForSyntheticProbes(entrypoint, {
+  const results = await runEntrypointSyntheticProbes(entrypoint, {
     mockSdk,
     pluginRoot,
     apiOptions: { retainHandlers: true },
-  });
-  const results = await runCapturedSyntheticProbes(capture, {
     includeLifecycle,
     includeChannelRuntime,
     includeProviderCapabilities,
@@ -50,30 +41,6 @@ async function run(commandArgs) {
   } else {
     process.stdout.write(json);
   }
-}
-
-async function captureForSyntheticProbes(entrypoint, options) {
-  if (options.mockSdk !== true) {
-    return captureEntrypoint(entrypoint, options);
-  }
-
-  const resolvedEntrypoint = path.resolve(process.cwd(), entrypoint);
-  const pluginRoot = path.resolve(process.cwd(), options.pluginRoot ?? path.dirname(resolvedEntrypoint));
-  const workspace = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-synthetic-mock-sdk-"));
-  cleanupTempDirOnExit(workspace);
-  const { loaderPath } = await createMockSdkPackage(workspace, { pluginRoot });
-  register(pathToFileURL(loaderPath));
-  return captureEntrypoint(entrypoint, {
-    ...options,
-    mockSdk: false,
-    pluginRoot,
-  });
-}
-
-function cleanupTempDirOnExit(dir) {
-  process.once("exit", () => {
-    rmSync(dir, { force: true, recursive: true });
-  });
 }
 
 function readFlag(commandArgs, name) {

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -267,12 +267,17 @@ export const defaultSyntheticHookEvents = {
     runId: "run-fixture",
     agentId: "agent-fixture",
     conversationId: "conversation-fixture",
+    success: true,
+    durationMs: 1,
+    error: null,
+    messages: [{ role: "assistant", content: "[redacted fixture output]" }],
     status: "completed",
     transcript: [{ role: "assistant", content: "[redacted fixture output]" }],
   },
   before_agent_start: {
     agentId: "agent-fixture",
     runId: "run-fixture",
+    prompt: "fixture prompt",
     config: { source: "plugin-inspector" },
   },
   before_prompt_build: {
@@ -302,6 +307,18 @@ export const defaultSyntheticHookEvents = {
     agentId: "agent-fixture",
     model: "gpt-5.4",
     output: { role: "assistant", content: "[redacted fixture output]" },
+  },
+  message_received: {
+    from: "fixture-user",
+    content: "fixture inbound message",
+    messageId: "message-fixture",
+  },
+  message_sent: {
+    to: "fixture-user",
+    content: "fixture outbound message",
+    success: true,
+    error: null,
+    messageId: "message-fixture-reply",
   },
   subagent_delivery_target: {
     childSessionKey: "child-session",
@@ -360,6 +377,18 @@ export const defaultSyntheticHookContexts = {
     runId: "run-fixture",
     agentId: "agent-fixture",
     sessionId: "session-fixture",
+  },
+  message_received: {
+    runId: "run-fixture",
+    agentId: "agent-fixture",
+    sessionId: "session-fixture",
+    channelId: "fixture-channel",
+  },
+  message_sent: {
+    runId: "run-fixture",
+    agentId: "agent-fixture",
+    sessionId: "session-fixture",
+    channelId: "fixture-channel",
   },
   subagent_delivery_target: {
     runId: "run-fixture",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -50,6 +50,7 @@ import {
   reports,
   runtime,
   runCapturedSyntheticProbes,
+  runEntrypointSyntheticProbes,
   runFixtureSetColdImportReadiness,
   runFixtureSetPlatformProbes,
   runFixtureSetReport,
@@ -126,6 +127,7 @@ test("public API exposes grouped facades for common workflows", () => {
   assert.equal(runtime.buildRefDiff, buildRefDiff);
   assert.equal(synthetic.buildPlanFromReport, buildSyntheticProbePlanFromReport);
   assert.equal(synthetic.runCaptured, runCapturedSyntheticProbes);
+  assert.equal(synthetic.runEntrypoint, runEntrypointSyntheticProbes);
 });
 
 test("public API reads plugin config from package.json", async () => {
@@ -594,6 +596,7 @@ test("public API exposes synthetic probe helpers", async () => {
   });
 
   assert.equal(typeof runCapturedSyntheticProbes, "function");
+  assert.equal(typeof runEntrypointSyntheticProbes, "function");
   assert.deepEqual(validateSyntheticProbePlan(plan), []);
   assert.match(renderSyntheticProbeMarkdown(plan), /registerTool/);
   assert.equal(JSON.parse(await readFile(paths.jsonPath, "utf8")).summary.probeCount, 2);

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -197,6 +197,58 @@ test("capture entrypoint can mock OpenClaw plugin SDK imports", async () => {
   );
 });
 
+test("mock capture ignores type-only root SDK imports", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-mock-sdk-type-import-"));
+  const entrypoint = path.join(dir, "index.ts");
+  await writeFile(
+    entrypoint,
+    [
+      'import type { OpenClawPluginApi } from "openclaw/plugin-sdk";',
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      "",
+      "export default definePluginEntry((api: OpenClawPluginApi) => {",
+      "  api.on('before_tool_call', () => undefined);",
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await captureEntrypoint("index.ts", {
+    cwd: dir,
+    pluginRoot: dir,
+    mockSdk: true,
+  });
+
+  assert.equal(result.status, "captured");
+  assert.deepEqual(result.captured.map((item) => `${item.kind}:${item.name}`), ["hook:before_tool_call"]);
+});
+
+test("mock capture supports unknown runtime root SDK exports", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-mock-sdk-dynamic-root-"));
+  const entrypoint = path.join(dir, "index.mjs");
+  await writeFile(
+    entrypoint,
+    [
+      'import { definePluginEntry, futureRuntimeHelper } from "openclaw/plugin-sdk";',
+      "",
+      "futureRuntimeHelper.normalizeFixture?.('fixture');",
+      "export default definePluginEntry((api) => {",
+      "  api.registerTool({ name: 'fixture_tool', run() {} });",
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await captureEntrypoint("index.mjs", {
+    cwd: dir,
+    pluginRoot: dir,
+    mockSdk: true,
+  });
+
+  assert.equal(result.status, "captured");
+  assert.deepEqual(result.captured.map((item) => `${item.kind}:${item.name}`), ["registration:registerTool"]);
+});
+
 test("mock capture accepts valid output when plugin code dirties process exit code", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-mock-exit-code-"));
   const entrypoint = path.join(dir, "index.mjs");

--- a/test/runtime-capture-report.test.js
+++ b/test/runtime-capture-report.test.js
@@ -314,7 +314,6 @@ test("runtime capture synthesizes manifest config before plugin registration", a
             autoCapture: { type: "boolean" },
             autoRecall: { type: "boolean" },
           },
-          required: ["embedding"],
         },
       },
       null,
@@ -341,7 +340,6 @@ test("runtime capture synthesizes manifest config before plugin registration", a
 
   const result = await captureEntrypoint("src/index.ts", {
     cwd: rootDir,
-    pluginRoot: rootDir,
     mockSdk: true,
   });
 

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -6,8 +6,11 @@ import { test } from "node:test";
 import {
   buildSyntheticProbePlan,
   captureEntrypoint,
+  defaultSyntheticHookContexts,
+  defaultSyntheticHookEvents,
   renderSyntheticProbeMarkdown,
   runCapturedSyntheticProbes,
+  runEntrypointSyntheticProbes,
   validateSyntheticProbePlan,
 } from "../src/advanced.js";
 import { buildSyntheticProbePlanFromReport } from "../src/synthetic-probe-suite.js";
@@ -182,6 +185,13 @@ test("synthetic probe plan classifies generated kitchen-sink registrars", () => 
   assert.deepEqual(validateSyntheticProbePlan(plan), []);
 });
 
+test("default hook payloads cover message and agent lifecycle readers", () => {
+  assert.equal(typeof defaultSyntheticHookEvents.before_agent_start.prompt, "string");
+  assert.equal(typeof defaultSyntheticHookEvents.message_received.content, "string");
+  assert.equal(defaultSyntheticHookEvents.agent_end.success, true);
+  assert.equal(defaultSyntheticHookContexts.message_sent.channelId, "fixture-channel");
+});
+
 test("synthetic probes invoke retained hook and tool handlers", async () => {
   const capture = await captureLocalFixture([
     "export function register(api) {",
@@ -320,6 +330,37 @@ test("mock SDK capture preserves retained registration metadata across subproces
   assert.equal(capture.retained.length, 1);
   assert.equal(result.summary.blockedCount, 1);
   assert.match(result.results[0].reason, /no supported callable probe/);
+});
+
+test("mock SDK entrypoint synthetic probes execute retained handlers in-process", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-mock-sdk-entrypoint-"));
+  const entrypoint = path.join(dir, "fixture.ts");
+  await writeFile(
+    entrypoint,
+    [
+      'import type { OpenClawPluginApi } from "openclaw/plugin-sdk";',
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      "",
+      "export default definePluginEntry((api: OpenClawPluginApi) => {",
+      "  api.on('before_tool_call', (event) => ({ seen: event.toolName }));",
+      "  api.registerTool({ name: 'fixture_tool', run(params) { return { sawParams: typeof params === 'object' }; } });",
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runEntrypointSyntheticProbes("fixture.ts", {
+    cwd: dir,
+    pluginRoot: dir,
+    mockSdk: true,
+  });
+
+  assert.equal(result.summary.failCount, 0);
+  assert.equal(result.summary.blockedCount, 0);
+  assert.deepEqual(
+    result.results.map((item) => `${item.status}:${item.kind}:${item.label}`),
+    ["pass:hook:before_tool_call", "pass:registration:registerTool.run"],
+  );
 });
 
 async function captureLocalFixture(lines) {


### PR DESCRIPTION
## Summary

- keeps mock-SDK synthetic entrypoint probes in-process so captured hook handlers remain callable
- teaches the mock SDK generator to ignore type-only SDK imports and provide runtime fallback exports for unknown root SDK symbols
- improves default synthetic lifecycle payloads and manifest config discovery for built `dist/` entrypoints

## Root cause

Synthetic entrypoint probes captured in a child process and serialized the result, which dropped function handlers before the probe runner could invoke them. A second mock SDK gap made type-only/root SDK imports look like runtime export requirements.

## Verification

- `npm test` passed locally: 168/168
- `npm run release:contents` passed locally
- used by Crabpot beta fixture proof for `openclaw-telemetry` and `memory-lancedb`
