### PR TITLE
fix: warn on missing plugin manifest names

### DIFF
--- a/src/contract-probes.js
+++ b/src/contract-probes.js
@@ -114,6 +114,11 @@ export const contractProbeRules = {
     contract: "Package and OpenClaw manifest versions stay aligned for release compatibility reporting.",
     target: "package-loader",
   },
+  "manifest-name-missing": {
+    id: "manifest.metadata.name",
+    contract: "OpenClaw plugin manifests declare a human-readable display name for registry and tooling metadata.",
+    target: "manifest-loader",
+  },
   "package-plugin-api-compat-missing": {
     id: "package.compat.plugin-api-range",
     contract: "Package metadata declares the OpenClaw plugin API range used by the plugin.",

--- a/src/fixture-summary.js
+++ b/src/fixture-summary.js
@@ -233,6 +233,26 @@ export function classifyPackageContracts({ fixture, inspection, fixtureReport })
     });
   }
 
+  const missingManifestNames = fixtureReport.pluginManifests.filter(
+    (manifest) => typeof manifest.name !== "string" || manifest.name.trim().length === 0,
+  );
+  if (missingManifestNames.length > 0) {
+    warnings.push({
+      fixture: fixture.id,
+      code: "manifest-name-missing",
+      level: "warning",
+      message: "openclaw.plugin.json does not declare a display name",
+      evidence: missingManifestNames.map((manifest) => manifest.path ?? "openclaw.plugin.json"),
+    });
+    decisions.push({
+      fixture: fixture.id,
+      decision: "plugin-upstream-fix",
+      seam: "manifest-metadata",
+      action: "Ask the plugin to declare openclaw.plugin.json name so registries and tools can derive a human-readable title.",
+      evidence: missingManifestNames.map((manifest) => manifest.path ?? "openclaw.plugin.json").join(", "),
+    });
+  }
+
   if (packageSummary.openclaw && !packageSummary.openclaw.compatPluginApi) {
     warnings.push({
       fixture: fixture.id,

--- a/src/issues.js
+++ b/src/issues.js
@@ -14,6 +14,7 @@ export const knownIssueCodes = new Set([
   "conversation-access-hook",
   "legacy-before-agent-start",
   "legacy-root-sdk-import",
+  "manifest-name-missing",
   "manifest-unknown-contracts",
   "manifest-unknown-fields",
   "missing-expected-seam",
@@ -110,6 +111,12 @@ export const issueMetadataByCode = {
     owner: "inspector",
     decision: "inspector-follow-up",
     title: "fixture no longer exposes an expected seam",
+  },
+  "manifest-name-missing": {
+    severity: "P2",
+    owner: "plugin",
+    decision: "plugin-upstream-fix",
+    title: "manifest display name is missing",
   },
   "manifest-unknown-contracts": {
     severity: "P1",
@@ -372,6 +379,7 @@ function issueClassFor(code, options) {
     [
       "manifest-unknown-contracts",
       "manifest-unknown-fields",
+      "manifest-name-missing",
       "package-json-missing",
       "package-manifest-version-drift",
       "package-min-host-version-drift",

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -639,7 +639,13 @@ test("package contract classifier reports install and entrypoint blockers", () =
       registrations: ["registerTool"],
     },
     fixtureReport: {
-      pluginManifests: [{ version: "2.0.0" }],
+      pluginManifests: [
+        {
+          path: "plugins/fixture/openclaw.plugin.json",
+          name: null,
+          version: "2.0.0",
+        },
+      ],
       package: {
         path: "plugins/fixture/package.json",
         name: "fixture-plugin",
@@ -664,6 +670,7 @@ test("package contract classifier reports install and entrypoint blockers", () =
   });
 
   assert.ok(result.logs.some((finding) => finding.code === "package-metadata"));
+  assert.ok(result.warnings.some((finding) => finding.code === "manifest-name-missing"));
   assert.ok(result.warnings.some((finding) => finding.code === "package-manifest-version-drift"));
   assert.ok(result.warnings.some((finding) => finding.code === "package-plugin-api-compat-missing"));
   assert.ok(result.suggestions.some((finding) => finding.code === "package-build-artifact-entrypoint"));


### PR DESCRIPTION
## Summary
- add a `manifest-name-missing` warning when `openclaw.plugin.json.name` is missing or blank
- classify the warning as upstream plugin metadata and add a matching contract probe rule
- extend report coverage for the missing manifest name case

## Tests
- `node --test test/report.test.js`
- `npm test`
