### PR TITLE
fix: return concrete mock agent dirs

### DIFF
--- a/src/sdk-mock.js
+++ b/src/sdk-mock.js
@@ -671,6 +671,15 @@ function resolveExistingSourcePath(target) {
 ` : ""}
 function createMockValue(name) {
   function fn(...args) {
+    if (name === "resolveDefaultAgentDir") {
+      return mockAgentDir();
+    }
+    if (name === "resolveAgentDir") {
+      return mockAgentDir(args[1]);
+    }
+    if (name === "resolveUserPath") {
+      return typeof args[0] === "string" ? args[0] : mockAgentDir();
+    }
     if (name === "resolvePreferredOpenClawTmpDir") {
       return process.env.TMPDIR || "/tmp";
     }
@@ -705,6 +714,12 @@ function createMockValue(name) {
       return createMockValue(name);
     },
   });
+}
+
+function mockAgentDir(agentId = "main") {
+  const base = process.env.TMPDIR || process.env.TEMP || process.env.TMP || "/tmp";
+  const safeAgentId = String(agentId || "main").replace(/[^a-zA-Z0-9._-]/g, "-");
+  return base.replace(/[\\/]+$/, "") + "/plugin-inspector-openclaw/agents/" + safeAgentId + "/agent";
 }
 
 function createZNamespace() {

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -369,6 +369,39 @@ test("mock SDK entrypoint synthetic probes execute retained handlers in-process"
   );
 });
 
+test("mock SDK agent runtime path helpers return concrete paths", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-agent-dir-"));
+  const entrypoint = path.join(dir, "fixture.mjs");
+  await writeFile(
+    entrypoint,
+    [
+      'import path from "node:path";',
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      'import { resolveDefaultAgentDir } from "openclaw/plugin-sdk/agent-runtime";',
+      "",
+      "export default definePluginEntry((api) => {",
+      "  api.registerCommand({",
+      "    name: 'fixture-command',",
+      "    handler() {",
+      "      return { agentDir: path.resolve(resolveDefaultAgentDir({})) };",
+      "    },",
+      "  });",
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runEntrypointSyntheticProbes("fixture.mjs", {
+    cwd: dir,
+    pluginRoot: dir,
+    mockSdk: true,
+  });
+
+  assert.equal(result.summary.failCount, 0);
+  assert.equal(result.summary.blockedCount, 0);
+  assert.deepEqual(result.results[0].output, { type: "object", keys: ["agentDir"] });
+});
+
 async function captureLocalFixture(lines) {
   const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-"));
   const entrypoint = path.join(dir, "fixture.mjs");


### PR DESCRIPTION
## Summary
- Make the mock SDK return concrete temp-backed paths for agent runtime path helpers.
- Add a synthetic probe regression for `path.resolve(resolveDefaultAgentDir({}))` inside retained handlers.

## Verification
- `node --test test/synthetic-probes.test.js`
- `npm run check`
