### PR TITLE
fix: mock windows spawn helpers

### DIFF
--- a/src/sdk-mock.js
+++ b/src/sdk-mock.js
@@ -680,6 +680,12 @@ function createMockValue(name) {
     if (name === "resolveUserPath") {
       return typeof args[0] === "string" ? args[0] : mockAgentDir();
     }
+    if (name === "resolveWindowsSpawnProgram") {
+      return mockWindowsSpawnProgram(args[0]);
+    }
+    if (name === "materializeWindowsSpawnProgram") {
+      return mockWindowsSpawnInvocation(args[0], args[1]);
+    }
     if (name === "resolvePreferredOpenClawTmpDir") {
       return process.env.TMPDIR || "/tmp";
     }
@@ -720,6 +726,34 @@ function mockAgentDir(agentId = "main") {
   const base = process.env.TMPDIR || process.env.TEMP || process.env.TMP || "/tmp";
   const safeAgentId = String(agentId || "main").replace(/[^a-zA-Z0-9._-]/g, "-");
   return base.replace(/[\\/]+$/, "") + "/plugin-inspector-openclaw/agents/" + safeAgentId + "/agent";
+}
+
+function mockWindowsSpawnProgram(params = {}) {
+  return {
+    command: typeof params.command === "string" && params.command.trim() ? params.command : process.execPath,
+    leadingArgv: [],
+    resolution: "mock",
+    packageName: typeof params.packageName === "string" ? params.packageName : undefined,
+  };
+}
+
+function mockWindowsSpawnInvocation(program = {}, argv = []) {
+  const command = typeof program.command === "string" && program.command.trim() ? program.command : process.execPath;
+  if (program.packageName === "@openai/codex") {
+    return {
+      command: process.execPath,
+      argv: ["-e", "process.exit(1)"],
+      resolution: program.resolution ?? "mock",
+      windowsHide: true,
+    };
+  }
+  return {
+    command,
+    argv: [...(Array.isArray(program.leadingArgv) ? program.leadingArgv : []), ...(Array.isArray(argv) ? argv : [])],
+    resolution: program.resolution ?? "mock",
+    shell: program.shell,
+    windowsHide: program.windowsHide,
+  };
 }
 
 function createZNamespace() {

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -402,6 +402,40 @@ test("mock SDK agent runtime path helpers return concrete paths", async () => {
   assert.deepEqual(result.results[0].output, { type: "object", keys: ["agentDir"] });
 });
 
+test("mock SDK windows spawn helpers return concrete invocations", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-windows-spawn-"));
+  const entrypoint = path.join(dir, "fixture.mjs");
+  await writeFile(
+    entrypoint,
+    [
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      'import { materializeWindowsSpawnProgram, resolveWindowsSpawnProgram } from "openclaw/plugin-sdk/windows-spawn";',
+      "",
+      "export default definePluginEntry((api) => {",
+      "  api.registerCommand({",
+      "    name: 'fixture-command',",
+      "    handler() {",
+      "      const program = resolveWindowsSpawnProgram({ command: 'codex', packageName: '@openai/codex' });",
+      "      const invocation = materializeWindowsSpawnProgram(program, ['app-server']);",
+      "      return { command: invocation.command, argv: invocation.argv };",
+      "    },",
+      "  });",
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const result = await runEntrypointSyntheticProbes("fixture.mjs", {
+    cwd: dir,
+    pluginRoot: dir,
+    mockSdk: true,
+  });
+
+  assert.equal(result.summary.failCount, 0);
+  assert.equal(result.summary.blockedCount, 0);
+  assert.deepEqual(result.results[0].output, { type: "object", keys: ["argv", "command"] });
+});
+
 async function captureLocalFixture(lines) {
   const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-"));
   const entrypoint = path.join(dir, "fixture.mjs");


### PR DESCRIPTION
## Summary
- Add concrete mock implementations for `resolveWindowsSpawnProgram` and `materializeWindowsSpawnProgram`.
- Keep mocked Codex app-server spawns side-effect-free during synthetic probes.
- Add retained-handler synthetic coverage for the windows-spawn SDK subpath.

## Verification
- `node --test test/synthetic-probes.test.js`
- `npm run check`
