### PR TITLE
fix: keep mocked codex app-server alive

### DIFF
--- a/src/sdk-mock.js
+++ b/src/sdk-mock.js
@@ -742,7 +742,7 @@ function mockWindowsSpawnInvocation(program = {}, argv = []) {
   if (program.packageName === "@openai/codex") {
     return {
       command: process.execPath,
-      argv: ["-e", "process.exit(1)"],
+      argv: ["-e", "setInterval(() => {}, 1000)"],
       resolution: program.resolution ?? "mock",
       windowsHide: true,
     };


### PR DESCRIPTION
## Summary
- Keep mocked Codex app-server processes alive long enough for client timeouts to handle them cleanly.
- Avoid immediate child-exit crashes during synthetic command probes.

## Verification
- `node --test test/synthetic-probes.test.js`
- `npm run check`
