### PR TITLE
fix: return empty mock auth profile order

### DIFF
--- a/src/sdk-mock.js
+++ b/src/sdk-mock.js
@@ -680,6 +680,9 @@ function createMockValue(name) {
     if (name === "resolveUserPath") {
       return typeof args[0] === "string" ? args[0] : mockAgentDir();
     }
+    if (name === "resolveAuthProfileOrder") {
+      return [];
+    }
     if (name === "resolveWindowsSpawnProgram") {
       return mockWindowsSpawnProgram(args[0]);
     }

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -377,13 +377,13 @@ test("mock SDK agent runtime path helpers return concrete paths", async () => {
     [
       'import path from "node:path";',
       'import { definePluginEntry } from "openclaw/plugin-sdk";',
-      'import { resolveDefaultAgentDir } from "openclaw/plugin-sdk/agent-runtime";',
+      'import { resolveAuthProfileOrder, resolveDefaultAgentDir } from "openclaw/plugin-sdk/agent-runtime";',
       "",
       "export default definePluginEntry((api) => {",
       "  api.registerCommand({",
       "    name: 'fixture-command',",
       "    handler() {",
-      "      return { agentDir: path.resolve(resolveDefaultAgentDir({})) };",
+      "      return { agentDir: path.resolve(resolveDefaultAgentDir({})), authProfiles: resolveAuthProfileOrder({}).length };",
       "    },",
       "  });",
       "});",
@@ -399,7 +399,7 @@ test("mock SDK agent runtime path helpers return concrete paths", async () => {
 
   assert.equal(result.summary.failCount, 0);
   assert.equal(result.summary.blockedCount, 0);
-  assert.deepEqual(result.results[0].output, { type: "object", keys: ["agentDir"] });
+  assert.deepEqual(result.results[0].output, { type: "object", keys: ["agentDir", "authProfiles"] });
 });
 
 test("mock SDK windows spawn helpers return concrete invocations", async () => {


### PR DESCRIPTION
Summary
- Return an empty concrete mock auth profile order from the synthetic SDK.
- Cover agent runtime helpers with path plus auth-profile output assertions.

Verification
- node --test test/synthetic-probes.test.js
- npm run check
