### PR TITLE
feat: flag file-backed SDK session identities

### DIFF
--- a/src/advanced.js
+++ b/src/advanced.js
@@ -124,6 +124,10 @@ export {
   inspectSourceText,
 } from "./inspector.js";
 export {
+  inspectSdkDeprecations,
+  pluginSdkDeprecationRules,
+} from "./sdk-deprecation-rules.js";
+export {
   defaultPluginRootConfigFiles,
   fixtureCheckoutPath,
   fixtureSourceRoot,

--- a/src/fixture-summary.js
+++ b/src/fixture-summary.js
@@ -49,6 +49,7 @@ export async function buildCompatibilityFixtureReport({ fixture, inspection, che
     packages: packageSummaries,
     sdkImports,
     sdkImportDetails: inspection.sdkImports ?? [],
+    sdkDeprecations: inspection.sdkDeprecations ?? [],
   };
 }
 
@@ -496,6 +497,7 @@ export function classifyCompatibilityFixture({ fixture, inspection, fixtureRepor
   logs.push(...packageContracts.logs);
   decisions.push(...packageContracts.decisions);
   classifySecurityManifestCoverage({ fixture, fixtureReport, warnings, decisions });
+  classifySdkDeprecationUsage({ fixture, inspection, fixtureReport, warnings, decisions });
 
   for (const pluginManifest of fixtureReport.pluginManifests) {
     const providerAuthKeys = Object.keys(pluginManifest.providerAuthEnvVars ?? {});
@@ -700,6 +702,26 @@ export function classifyCompatibilityFixture({ fixture, inspection, fixtureRepor
   }
 
   return { warnings, suggestions, logs, decisions };
+}
+
+function classifySdkDeprecationUsage({ fixture, inspection, fixtureReport, warnings, decisions }) {
+  const deprecations = inspection.sdkDeprecations ?? fixtureReport.sdkDeprecations ?? [];
+  for (const deprecation of deprecations) {
+    warnings.push({
+      fixture: fixture.id,
+      code: deprecation.code,
+      level: "warning",
+      message: deprecation.message,
+      evidence: [`${deprecation.property} @ ${deprecation.ref}`],
+    });
+    decisions.push({
+      fixture: fixture.id,
+      decision: "plugin-upstream-fix",
+      seam: "sdk-deprecation",
+      action: `Migrate ${deprecation.surface}.${deprecation.property} to ${deprecation.replacement} before the SQLite storage flip.`,
+      evidence: deprecation.ref,
+    });
+  }
 }
 
 function classifySecurityManifestCoverage({ fixture, fixtureReport, warnings, decisions }) {

--- a/src/index.js
+++ b/src/index.js
@@ -207,6 +207,7 @@ export {
 } from "./import-loop-profile.js";
 export { classifyIssueFinding, issueId, knownIssueCodes } from "./issues.js";
 export { inspectFixtureSet, inspectPlugin, inspectSourceText } from "./inspector.js";
+export { inspectSdkDeprecations, pluginSdkDeprecationRules } from "./sdk-deprecation-rules.js";
 export { openClawTargetPathCandidates, readOpenClawTargetSurface } from "./openclaw-target.js";
 export {
   buildProfileDiff,

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -10,6 +10,7 @@ import { fixtureCheckoutPath, fixtureSourceRoot } from "./config.js";
 import { buildCompatibilityFixtureReport } from "./fixture-summary.js";
 import { readOpenClawTargetSurface } from "./openclaw-target.js";
 import { buildCompatibilityReport, buildReport } from "./report.js";
+import { inspectSdkDeprecations } from "./sdk-deprecation-rules.js";
 
 const execFileAsync = promisify(execFile);
 const registrationEquivalents = new Map([
@@ -103,6 +104,7 @@ export async function inspectPlugin(fixture, options = {}) {
   const hookDetails = [];
   const registrationDetails = [];
   const sdkImportDetails = [];
+  const sdkDeprecationDetails = [];
 
   for (const filePath of files) {
     const text = await readFile(filePath, "utf8");
@@ -119,6 +121,9 @@ export async function inspectPlugin(fixture, options = {}) {
     }
     for (const sdkImport of sourceInspection.sdkImports) {
       sdkImportDetails.push(sdkImport);
+    }
+    for (const sdkDeprecation of sourceInspection.sdkDeprecations) {
+      sdkDeprecationDetails.push(sdkDeprecation);
     }
   }
 
@@ -139,6 +144,7 @@ export async function inspectPlugin(fixture, options = {}) {
     packageErrors: packageInspection.errors,
     packageEntrypoints: packageInspection.entrypoints,
     sdkImports: uniqueDetails(sdkImportDetails),
+    sdkDeprecations: uniqueDeprecationDetails(sdkDeprecationDetails),
     sourceFiles: files.map((filePath) => path.relative(config.rootDir ?? process.cwd(), filePath)).sort(),
   };
 }
@@ -159,11 +165,13 @@ export function inspectSourceText(text, filePath = "source.js") {
     filePath,
     "specifier",
   );
+  const sdkDeprecations = inspectSdkDeprecations(searchableText, filePath);
 
   return {
     hooks,
     registrations,
     sdkImports,
+    sdkDeprecations,
   };
 }
 
@@ -352,6 +360,7 @@ function emptyInspection(fixture, status) {
     packageErrors: [],
     packageEntrypoints: [],
     sdkImports: [],
+    sdkDeprecations: [],
     sourceFiles: [],
   };
 }
@@ -550,6 +559,14 @@ function uniqueDetails(details) {
   for (const detail of sortDetails(details)) {
     const key = `${detail.name ?? detail.specifier}:${detail.ref}`;
     byKey.set(key, detail);
+  }
+  return [...byKey.values()];
+}
+
+function uniqueDeprecationDetails(details) {
+  const byKey = new Map();
+  for (const detail of [...details].sort((left, right) => left.ref.localeCompare(right.ref))) {
+    byKey.set(`${detail.code}:${detail.surface}:${detail.property}:${detail.ref}`, detail);
   }
   return [...byKey.values()];
 }

--- a/src/issues.js
+++ b/src/issues.js
@@ -42,6 +42,7 @@ export const knownIssueCodes = new Set([
   "reserved-sdk-import",
   "security-manifest-schema-unavailable",
   "sdk-export-missing",
+  "sdk-session-transcript-file-identity",
   "unrecognized-security-manifest",
 ]);
 
@@ -87,6 +88,11 @@ export const issueMetadataByCode = {
     owner: "core",
     decision: "core-compat-adapter",
     title: "plugin SDK import aliases are missing from target package exports",
+  },
+  "sdk-session-transcript-file-identity": {
+    severity: "P2",
+    owner: "plugin",
+    decision: "plugin-upstream-fix",
   },
   "reserved-sdk-import": {
     severity: "P1",
@@ -358,7 +364,16 @@ function issueClassFor(code, options) {
   if (code === "missing-compat-record") {
     return "compat-gap";
   }
-  if (options.deprecated || ["channel-env-vars", "legacy-before-agent-start", "legacy-root-sdk-import", "provider-auth-env-vars"].includes(code)) {
+  if (
+    options.deprecated ||
+    [
+      "channel-env-vars",
+      "legacy-before-agent-start",
+      "legacy-root-sdk-import",
+      "provider-auth-env-vars",
+      "sdk-session-transcript-file-identity",
+    ].includes(code)
+  ) {
     return "deprecation-warning";
   }
   if (

--- a/src/report.js
+++ b/src/report.js
@@ -26,6 +26,7 @@ export function buildReport({ config, inspections, failures = [], generatedAt = 
       registrations: inspection.registrations,
       manifestContracts: inspection.manifestContracts,
       sdkImports: inspection.sdkImports,
+      sdkDeprecations: inspection.sdkDeprecations,
       sourceFiles: inspection.sourceFiles,
       manifestFiles: inspection.manifestFiles,
       packageFiles: inspection.packageFiles,
@@ -462,6 +463,7 @@ function defaultCompatibilityFixtureReport({ fixture, inspection }) {
     packages: [],
     sdkImports: inspection.sdkImports.map((sdkImport) => sdkImport.specifier).filter(Boolean),
     sdkImportDetails: inspection.sdkImports,
+    sdkDeprecations: inspection.sdkDeprecations,
   };
 }
 
@@ -480,6 +482,7 @@ function normalizeInspection(inspection, fixture) {
     packageErrors: [],
     packageEntrypoints: [],
     sdkImports: [],
+    sdkDeprecations: [],
     sourceFiles: [],
     ...inspection,
   };

--- a/src/sdk-deprecation-rules.js
+++ b/src/sdk-deprecation-rules.js
@@ -1,0 +1,439 @@
+const sdkImportPattern = /openclaw\/plugin-sdk(?:$|\/)/;
+
+/** Machine-readable plugin SDK deprecation rules consumed by static inspection. */
+export const pluginSdkDeprecationRules = [
+  {
+    code: "sdk-session-transcript-file-identity",
+    title: "Plugin SDK session/transcript file-backed identity is deprecated",
+    window: "pre-SQLite deprecation window",
+    namedExports: [],
+    functionOptions: [
+      {
+        imports: ["runEmbeddedAgent"],
+        surface: "runEmbeddedAgent options",
+        properties: [
+          {
+            name: "sessionFile",
+            replacement: "storage-neutral agent/session identity options",
+          },
+        ],
+      },
+      {
+        imports: ["emitSessionTranscriptUpdate"],
+        surface: "emitSessionTranscriptUpdate payload",
+        properties: [
+          {
+            name: "sessionFile",
+            replacement: "publishSessionTranscriptUpdateByIdentity with SessionTranscriptTarget",
+          },
+        ],
+      },
+      {
+        imports: ["appendSessionTranscriptMessage"],
+        surface: "appendSessionTranscriptMessage options",
+        properties: [
+          {
+            name: "sessionFile",
+            replacement: "appendSessionTranscriptMessageByIdentity with SessionTranscriptIdentity",
+          },
+          {
+            name: "transcriptPath",
+            replacement: "appendSessionTranscriptMessageByIdentity with SessionTranscriptIdentity",
+          },
+        ],
+      },
+    ],
+    memberOptions: [
+      {
+        objectType: "MemorySearchManager",
+        method: "sync",
+        surface: "MemorySearchManager.sync options",
+        properties: [
+          {
+            name: "sessionFiles",
+            replacement: "sessions: MemorySessionSyncTarget[]",
+          },
+        ],
+      },
+    ],
+    eventFields: [
+      {
+        callbacks: ["onSessionTranscriptUpdate"],
+        payloadType: "SessionTranscriptUpdate",
+        surface: "SessionTranscriptUpdate field",
+        fields: [
+          {
+            name: "sessionFile",
+            replacement: "structured update.target identity",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+/**
+ * Inspects plugin SDK source for advisory deprecation rules.
+ *
+ * The scanner intentionally avoids a parser dependency for this narrow rule set. It detects direct
+ * named or namespace SDK imports, balanced function calls with object-literal option keys, typed
+ * MemorySearchManager.sync calls, and direct SessionTranscriptUpdate payload member reads.
+ */
+export function inspectSdkDeprecations(text, filePath = "source.js", rules = pluginSdkDeprecationRules) {
+  const imports = collectSdkImports(text);
+  if (imports.named.size === 0 && imports.namespaces.size === 0) {
+    return [];
+  }
+
+  const findings = [];
+  for (const rule of rules) {
+    collectNamedExportDeprecations(findings, { rule, imports, text, filePath });
+    collectFunctionOptionDeprecations(findings, { rule, imports, text, filePath });
+    collectMemberOptionDeprecations(findings, { rule, imports, text, filePath });
+    collectEventFieldDeprecations(findings, { rule, imports, text, filePath });
+  }
+
+  return uniqueFindings(findings)
+    .sort((left, right) => left.offset - right.offset || left.surface.localeCompare(right.surface))
+    .map(({ offset, ...finding }) => finding);
+}
+
+function collectSdkImports(text) {
+  const imports = { named: new Map(), namespaces: new Map() };
+  const regex = /\bimport\s+(type\s+)?(?:(\*\s+as\s+([A-Za-z_$][\w$]*))|{([^}]+)}|([A-Za-z_$][\w$]*))?\s*from\s*["'`]([^"'`]+)["'`]/g;
+  for (const match of text.matchAll(regex)) {
+    const specifier = match[6];
+    if (!sdkImportPattern.test(specifier)) {
+      continue;
+    }
+
+    if (match[3]) {
+      addImportBinding(imports.namespaces, "*", match[3], { specifier, typeOnly: false });
+      continue;
+    }
+
+    if (match[4]) {
+      for (const binding of parseNamedImportBindings(match[4], Boolean(match[1]), specifier)) {
+        addImportBinding(imports.named, binding.imported, binding.local, binding);
+      }
+      continue;
+    }
+
+    if (match[5]) {
+      addImportBinding(imports.named, "default", match[5], { specifier, typeOnly: Boolean(match[1]) });
+    }
+  }
+  return imports;
+}
+
+function parseNamedImportBindings(rawBindings, importTypeOnly, specifier) {
+  return rawBindings
+    .split(",")
+    .map((binding) => binding.trim())
+    .filter(Boolean)
+    .map((binding) => {
+      const typeOnly = importTypeOnly || binding.startsWith("type ");
+      const normalized = binding.replace(/^type\s+/, "").trim();
+      const [imported, local = imported] = normalized.split(/\s+as\s+/);
+      return { imported: imported.trim(), local: local.trim(), specifier, typeOnly };
+    })
+    .filter((binding) => binding.imported && binding.local);
+}
+
+function addImportBinding(bindings, imported, local, binding) {
+  const existing = bindings.get(imported) ?? [];
+  existing.push({ ...binding, imported, local });
+  bindings.set(imported, existing);
+}
+
+function collectNamedExportDeprecations(findings, context) {
+  for (const exportRule of context.rule.namedExports ?? []) {
+    for (const binding of context.imports.named.get(exportRule.name) ?? []) {
+      findings.push(
+        buildFinding(context.rule, {
+          surface: `${binding.specifier} export`,
+          property: exportRule.name,
+          replacement: exportRule.replacement,
+          sourceText: context.text,
+          filePath: context.filePath,
+          offset: 0,
+        }),
+      );
+    }
+  }
+}
+
+function collectFunctionOptionDeprecations(findings, context) {
+  for (const optionRule of context.rule.functionOptions ?? []) {
+    const localNames = optionRule.imports.flatMap((name) =>
+      (context.imports.named.get(name) ?? []).filter((binding) => !binding.typeOnly).map((binding) => binding.local),
+    );
+    for (const localName of localNames) {
+      for (const call of findCallRanges(context.text, localName)) {
+        collectPropertyFindings(findings, context.rule, optionRule, context.filePath, context.text, call.body, call.bodyOffset);
+      }
+    }
+
+    for (const namespace of importedNamespaceNames(context.imports)) {
+      for (const importedName of optionRule.imports) {
+        for (const call of findCallRanges(context.text, `${namespace}.${importedName}`)) {
+          collectPropertyFindings(findings, context.rule, optionRule, context.filePath, context.text, call.body, call.bodyOffset);
+        }
+      }
+    }
+  }
+}
+
+function collectMemberOptionDeprecations(findings, context) {
+  for (const optionRule of context.rule.memberOptions ?? []) {
+    const objectTypeNames = importedLocalNames(context.imports, optionRule.objectType);
+    const objectNames = objectTypeNames.flatMap((typeName) => typedIdentifiers(context.text, typeName));
+    for (const objectName of objectNames) {
+      for (const call of findMemberCallRanges(context.text, objectName, optionRule.method)) {
+        collectPropertyFindings(findings, context.rule, optionRule, context.filePath, context.text, call.body, call.bodyOffset);
+      }
+    }
+  }
+}
+
+function collectEventFieldDeprecations(findings, context) {
+  for (const eventRule of context.rule.eventFields ?? []) {
+    const payloadTypeNames = importedLocalNames(context.imports, eventRule.payloadType);
+    const typedPayloadNames = payloadTypeNames.flatMap((typeName) => typedIdentifiers(context.text, typeName));
+    for (const payloadName of typedPayloadNames) {
+      collectPayloadFieldFindings(findings, context.rule, eventRule, context.filePath, context.text, context.text, 0, payloadName);
+    }
+
+    const callbackNames = eventRule.callbacks.flatMap((name) =>
+      (context.imports.named.get(name) ?? []).filter((binding) => !binding.typeOnly).map((binding) => binding.local),
+    );
+    for (const callbackName of callbackNames) {
+      for (const call of findCallRanges(context.text, callbackName)) {
+        for (const field of eventRule.fields) {
+          collectDestructuredPayloadField(
+            findings,
+            context.rule,
+            eventRule,
+            field,
+            context.filePath,
+            context.text,
+            call.body,
+            call.bodyOffset,
+          );
+        }
+        const payloadName = callbackPayloadName(call.body, eventRule.payloadType);
+        if (payloadName) {
+          collectPayloadFieldFindings(
+            findings,
+            context.rule,
+            eventRule,
+            context.filePath,
+            context.text,
+            call.body,
+            call.bodyOffset,
+            payloadName,
+          );
+        }
+      }
+    }
+  }
+}
+
+function collectPropertyFindings(findings, rule, optionRule, filePath, sourceText, text, baseOffset) {
+  for (const property of optionRule.properties) {
+    for (const match of propertyMatches(text, property.name)) {
+      findings.push(
+        buildFinding(rule, {
+          surface: optionRule.surface,
+          property: property.name,
+          replacement: property.replacement,
+          sourceText,
+          filePath,
+          offset: baseOffset + match.offset,
+        }),
+      );
+    }
+  }
+}
+
+function collectPayloadFieldFindings(findings, rule, eventRule, filePath, sourceText, text, baseOffset, payloadName) {
+  for (const field of eventRule.fields) {
+    const regex = new RegExp(`${escapeRegex(payloadName)}\\s*\\.\\s*${escapeRegex(field.name)}\\b`, "g");
+    for (const match of text.matchAll(regex)) {
+      findings.push(
+        buildFinding(rule, {
+          surface: eventRule.surface,
+          property: field.name,
+          replacement: field.replacement,
+          sourceText,
+          filePath,
+          offset: baseOffset + (match.index ?? 0),
+        }),
+      );
+    }
+  }
+}
+
+function collectDestructuredPayloadField(findings, rule, eventRule, field, filePath, sourceText, text, baseOffset) {
+  const regex = new RegExp(`\\(\\s*{[^}]*\\b${escapeRegex(field.name)}\\b`, "g");
+  for (const match of text.matchAll(regex)) {
+    findings.push(
+      buildFinding(rule, {
+        surface: eventRule.surface,
+        property: field.name,
+        replacement: field.replacement,
+        sourceText,
+        filePath,
+        offset: baseOffset + (match.index ?? 0) + match[0].lastIndexOf(field.name),
+      }),
+    );
+  }
+}
+
+function buildFinding(rule, details) {
+  const refLine = lineForOffset(details.sourceText, details.offset);
+  return {
+    code: rule.code,
+    surface: details.surface,
+    property: details.property,
+    replacement: details.replacement,
+    ref: `${details.filePath}:${refLine}`,
+    message: `${details.surface}.${details.property} is supported only during the ${rule.window}; use ${details.replacement}.`,
+    offset: details.offset,
+  };
+}
+
+function importedNamespaceNames(imports) {
+  return (imports.namespaces.get("*") ?? []).map((binding) => binding.local);
+}
+
+function importedLocalNames(imports, importedName) {
+  return (imports.named.get(importedName) ?? []).map((binding) => binding.local);
+}
+
+function typedIdentifiers(text, typeName) {
+  const identifiers = new Set();
+  const typePattern = escapeRegex(typeName);
+  const variableRegex = new RegExp(
+    `\\b(?:declare\\s+)?(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*:\\s*${typePattern}\\b`,
+    "g",
+  );
+  for (const match of text.matchAll(variableRegex)) {
+    identifiers.add(match[1]);
+  }
+
+  const parameterRegex = new RegExp(`\\b([A-Za-z_$][\\w$]*)\\s*:\\s*${typePattern}\\b`, "g");
+  for (const match of text.matchAll(parameterRegex)) {
+    identifiers.add(match[1]);
+  }
+  return [...identifiers];
+}
+
+function callbackPayloadName(text, payloadType) {
+  const typed = new RegExp(`\\(?\\s*([A-Za-z_$][\\w$]*)\\s*:\\s*${escapeRegex(payloadType)}\\b`).exec(text);
+  if (typed?.[1]) {
+    return typed[1];
+  }
+
+  const untyped = /\(?\s*([A-Za-z_$][\w$]*)\s*\)?\s*=>/.exec(text);
+  return untyped?.[1] ?? null;
+}
+
+function findCallRanges(text, callee) {
+  const ranges = [];
+  const regex = new RegExp(`\\b${escapeRegex(callee)}\\s*\\(`, "g");
+  for (const match of text.matchAll(regex)) {
+    const openParen = (match.index ?? 0) + match[0].lastIndexOf("(");
+    const closeParen = findClosingDelimiter(text, openParen, "(", ")");
+    if (closeParen > openParen) {
+      ranges.push({
+        body: text.slice(openParen + 1, closeParen),
+        bodyOffset: openParen + 1,
+      });
+    }
+  }
+  return ranges;
+}
+
+function findMemberCallRanges(text, objectName, methodName) {
+  const ranges = [];
+  const regex = new RegExp(`\\b${escapeRegex(objectName)}\\s*\\.\\s*${escapeRegex(methodName)}\\s*(?:\\?\\.)?\\s*\\(`, "g");
+  for (const match of text.matchAll(regex)) {
+    const openParen = (match.index ?? 0) + match[0].lastIndexOf("(");
+    const closeParen = findClosingDelimiter(text, openParen, "(", ")");
+    if (closeParen > openParen) {
+      ranges.push({
+        body: text.slice(openParen + 1, closeParen),
+        bodyOffset: openParen + 1,
+      });
+    }
+  }
+  return ranges;
+}
+
+function findClosingDelimiter(text, openOffset, openDelimiter, closeDelimiter) {
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  for (let index = openOffset; index < text.length; index += 1) {
+    const char = text[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === openDelimiter) {
+      depth += 1;
+      continue;
+    }
+    if (char === closeDelimiter) {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function propertyMatches(text, propertyName) {
+  const matches = [];
+  const regex = new RegExp(`(^|[,{]\\s*)(?:["'\`]${escapeRegex(propertyName)}["'\`]|${escapeRegex(propertyName)})\\s*(?=[:,])`, "gm");
+  for (const match of text.matchAll(regex)) {
+    const propertyOffset = (match.index ?? 0) + match[0].lastIndexOf(propertyName);
+    matches.push({ offset: propertyOffset });
+  }
+  return matches;
+}
+
+function uniqueFindings(findings) {
+  const byKey = new Map();
+  for (const finding of findings) {
+    byKey.set(`${finding.code}:${finding.surface}:${finding.property}:${finding.ref}`, finding);
+  }
+  return [...byKey.values()];
+}
+
+function lineForOffset(text, offset) {
+  let line = 1;
+  for (let index = 0; index < offset; index += 1) {
+    if (text.charCodeAt(index) === 10) {
+      line += 1;
+    }
+  }
+  return line;
+}
+
+function escapeRegex(value) {
+  return String(value).replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}

--- a/src/sdk-deprecation-rules.js
+++ b/src/sdk-deprecation-rules.js
@@ -411,9 +411,65 @@ function propertyMatches(text, propertyName) {
   const regex = new RegExp(`(^|[,{]\\s*)(?:["'\`]${escapeRegex(propertyName)}["'\`]|${escapeRegex(propertyName)})\\s*(?=[:,])`, "gm");
   for (const match of text.matchAll(regex)) {
     const propertyOffset = (match.index ?? 0) + match[0].lastIndexOf(propertyName);
-    matches.push({ offset: propertyOffset });
+    if (isTopLevelObjectProperty(text, propertyOffset)) {
+      matches.push({ offset: propertyOffset });
+    }
   }
   return matches;
+}
+
+function isTopLevelObjectProperty(text, propertyOffset) {
+  let objectDepth = 0;
+  let objectStart = -1;
+  let quote = null;
+  let escaped = false;
+
+  for (let index = 0; index < propertyOffset; index += 1) {
+    const char = text[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") {
+      objectDepth += 1;
+      if (objectDepth === 1) {
+        objectStart = index;
+      }
+    } else if (char === "}") {
+      objectDepth = Math.max(0, objectDepth - 1);
+    }
+  }
+
+  return objectDepth === 1 && isDirectArgumentObject(text, objectStart);
+}
+
+function isDirectArgumentObject(text, objectStart) {
+  if (objectStart < 0) {
+    return false;
+  }
+
+  let index = objectStart - 1;
+  while (index >= 0 && /\s/.test(text[index])) {
+    index -= 1;
+  }
+  while (text[index] === "(") {
+    index -= 1;
+    while (index >= 0 && /\s/.test(text[index])) {
+      index -= 1;
+    }
+  }
+  return index < 0 || text[index] === ",";
 }
 
 function uniqueFindings(findings) {

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -109,6 +109,84 @@ test("source inspection does not warn on unrelated SDK imports or local sessionF
   assert.deepEqual(inspection.sdkDeprecations, []);
 });
 
+test("source inspection ignores nested local sessionFile properties inside SDK options", () => {
+  const inspection = inspectSourceText(
+    [
+      'import { runEmbeddedAgent } from "openclaw/plugin-sdk/agent-harness-runtime";',
+      "",
+      "runEmbeddedAgent({",
+      "  metadata: {",
+      '    sessionFile: "/tmp/not-an-sdk-option.jsonl",',
+      "  },",
+      '  sessionId: "session-1",',
+      "});",
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(inspection.sdkDeprecations, []);
+});
+
+test("source inspection supports deprecated SDK option keys in later object arguments", () => {
+  const inspection = inspectSourceText(
+    [
+      'import { runEmbeddedAgent } from "openclaw/plugin-sdk/agent-harness-runtime";',
+      "",
+      "runEmbeddedAgent(context, {",
+      '  sessionFile: "/tmp/session.jsonl",',
+      "});",
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(
+    inspection.sdkDeprecations.map((finding) => `${finding.surface}:${finding.property}@${finding.ref}`),
+    ["runEmbeddedAgent options:sessionFile@plugins/example/index.ts:4"],
+  );
+});
+
+test("source inspection supports parenthesized SDK option object literals", () => {
+  const inspection = inspectSourceText(
+    [
+      'import { runEmbeddedAgent } from "openclaw/plugin-sdk/agent-harness-runtime";',
+      "",
+      "runEmbeddedAgent(context, ({",
+      '  sessionFile: "/tmp/session.jsonl",',
+      "}));",
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(
+    inspection.sdkDeprecations.map((finding) => `${finding.surface}:${finding.property}@${finding.ref}`),
+    ["runEmbeddedAgent options:sessionFile@plugins/example/index.ts:4"],
+  );
+});
+
+test("source inspection supports aliased and namespace SDK deprecation usage", () => {
+  const inspection = inspectSourceText(
+    [
+      'import * as harness from "openclaw/plugin-sdk/agent-harness-runtime";',
+      'import { onSessionTranscriptUpdate as onTranscript } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";',
+      "",
+      "harness.runEmbeddedAgent({",
+      '  sessionFile: "/tmp/session.jsonl",',
+      "});",
+      "",
+      "onTranscript(({ sessionFile }) => sessionFile);",
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(
+    inspection.sdkDeprecations.map((finding) => `${finding.surface}:${finding.property}@${finding.ref}`),
+    [
+      "runEmbeddedAgent options:sessionFile@plugins/example/index.ts:5",
+      "SessionTranscriptUpdate field:sessionFile@plugins/example/index.ts:8",
+    ],
+  );
+});
+
 test("fixture set inspection produces a passing report", async () => {
   const config = await loadInspectorConfig("test/fixtures/inspector.config.json");
   const report = await inspectFixtureSet(config);

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -55,6 +55,60 @@ test("source inspection strips long comments before matching registrations", () 
   );
 });
 
+test("source inspection records SDK session transcript deprecation evidence", () => {
+  const inspection = inspectSourceText(
+    [
+      'import { runEmbeddedAgent } from "openclaw/plugin-sdk/agent-harness-runtime";',
+      'import { onSessionTranscriptUpdate } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";',
+      'import type { MemorySearchManager, SessionTranscriptUpdate } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";',
+      "",
+      "declare const memory: MemorySearchManager;",
+      "",
+      "runEmbeddedAgent({",
+      '  sessionFile: "/tmp/session.jsonl",',
+      '  sessionId: "session-1",',
+      "});",
+      "",
+      "memory.sync?.({",
+      '  sessionFiles: ["/tmp/session.jsonl"],',
+      '  reason: "fixture",',
+      "});",
+      "",
+      "onSessionTranscriptUpdate((update: SessionTranscriptUpdate) => {",
+      "  return update.sessionFile;",
+      "});",
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(
+    inspection.sdkDeprecations.map((finding) => `${finding.surface}:${finding.property}@${finding.ref}`),
+    [
+      "runEmbeddedAgent options:sessionFile@plugins/example/index.ts:8",
+      "MemorySearchManager.sync options:sessionFiles@plugins/example/index.ts:13",
+      "SessionTranscriptUpdate field:sessionFile@plugins/example/index.ts:18",
+    ],
+  );
+});
+
+test("source inspection does not warn on unrelated SDK imports or local sessionFile objects", () => {
+  const inspection = inspectSourceText(
+    [
+      'import { definePluginEntry } from "openclaw/plugin-sdk";',
+      "",
+      "const localState = {",
+      '  sessionFile: "/tmp/local.jsonl",',
+      "};",
+      "",
+      "export default definePluginEntry({ register() {} });",
+      "console.log(localState.sessionFile);",
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(inspection.sdkDeprecations, []);
+});
+
 test("fixture set inspection produces a passing report", async () => {
   const config = await loadInspectorConfig("test/fixtures/inspector.config.json");
   const report = await inspectFixtureSet(config);

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -1101,6 +1101,59 @@ test("compatibility fixture classifier reports seam and metadata follow-ups", ()
   );
 });
 
+test("compatibility fixture classifier reports SDK deprecation notices", () => {
+  const result = classifyCompatibilityFixture({
+    fixture: { id: "fixture", path: "plugins/fixture" },
+    inspection: {
+      status: "ok",
+      hooks: [],
+      hookDetails: [],
+      registrations: [],
+      registrationDetails: [],
+      manifestContracts: [],
+      sdkDeprecations: [
+        {
+          code: "sdk-session-transcript-file-identity",
+          surface: "runEmbeddedAgent options",
+          property: "sessionFile",
+          ref: "plugins/fixture/src/index.ts:7",
+          replacement: "storage-neutral agent/session identity options",
+          message:
+            "runEmbeddedAgent options.sessionFile is supported only during the pre-SQLite deprecation window; use storage-neutral agent/session identity options.",
+        },
+      ],
+    },
+    fixtureReport: {
+      sdkImports: [],
+      sdkImportDetails: [],
+      pluginManifests: [],
+      securityManifests: [],
+      package: {
+        path: "plugins/fixture/package.json",
+        dependencies: [],
+        peerDependencies: [],
+        optionalDependencies: [],
+        openclaw: {
+          compatPluginApi: "^1.0.0",
+          entrypoints: [],
+        },
+      },
+    },
+    targetOpenClaw: {
+      status: "not-configured",
+    },
+  });
+
+  const warning = result.warnings.find((finding) => finding.code === "sdk-session-transcript-file-identity");
+  assert.deepEqual(warning.evidence, ["sessionFile @ plugins/fixture/src/index.ts:7"]);
+  assert.ok(result.decisions.some((decision) => decision.seam === "sdk-deprecation"));
+
+  const issues = buildIssues({ warnings: result.warnings, targetOpenClaw: { status: "not-configured" } });
+  const issue = issues.find((finding) => finding.code === "sdk-session-transcript-file-identity");
+  assert.equal(issue.issueClass, "deprecation-warning");
+  assert.match(issue.title, /pre-SQLite deprecation window/);
+});
+
 test("writeReport writes JSON and Markdown artifacts", async () => {
   const outDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-report-"));
   const config = await loadInspectorConfig("test/fixtures/inspector.config.json");


### PR DESCRIPTION
## What

Adds targeted Plugin SDK deprecation notices for SQLite session/transcript migration hazards. The scanner reports file-backed session/transcript identifiers only when plugin source uses known offending SDK surfaces, such as `runEmbeddedAgent({ sessionFile })`, `MemorySearchManager.sync({ sessionFiles })`, or `SessionTranscriptUpdate.sessionFile` reads.

## Why

This keeps migration guidance focused on the specific SDK usages that need action for the SQLite storage migration, without turning every existing OpenClaw `@deprecated` comment into plugin-inspector noise.

## Changes

- Adds a small machine-readable SDK deprecation rule pack.
- Records SDK deprecation findings during static source inspection.
- Classifies findings as `deprecation-warning` issues.
- Includes findings in fixture, report, SARIF, and JUnit flows through existing issue data.
- Adds focused false-positive coverage for unrelated imports, nested local `sessionFile` objects, aliased imports, namespace imports, and parenthesized option objects.

## Real behavior proof

- `node --test test/inspector.test.js test/report.test.js`
  - `40` tests passed.
- `npm test`
  - `179` tests passed.
- `npm run release:contents`
  - package contents passed.
- `git diff --check`
  - no whitespace errors.
- Autoreview:
  - `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node --test test/inspector.test.js test/report.test.js"`
  - clean: no accepted/actionable findings.

## Scope

- Does not read global OpenClaw `@deprecated` metadata.
- Does not add new runtime execution requirements.
- Does not add runtime dependencies.
- Does not publish or bump the npm package version.

## Linked context

Related SQLite migration tracker: https://github.com/openclaw/openclaw/issues/88838

## Draft status

Draft while maintainers review whether the targeted rule set is complete and whether any additional SQLite migration SDK surfaces should be included before marking ready.


## Crabpot follow-through

- `npm run release:crabpot`
  - failed because `/Users/phaedrus/Projects/crabpot/scripts/plugin-inspector-source.mjs` is not updated to this PR SHA; no crabpot files were modified for this draft PR.
- Source-mode smoke against this branch:
  - `CRABPOT_PLUGIN_INSPECTOR_CLI=source CRABPOT_PLUGIN_INSPECTOR_DIR=/Users/phaedrus/.codex/worktrees/plugin-inspector-sdk-deprecation-notices npm run plugin-inspector:smoke`
  - failed with Crabpot's current compatibility baseline: `83` breakages, `113` issues, `0` SDK deprecation issues.
- Package-mode smoke:
  - `npm run plugin-inspector:smoke`
  - failed identically: `83` breakages, `113` issues, `0` SDK deprecation issues.

Interpretation: crabpot smoke is currently failing independently of this plugin-inspector branch; the new SDK deprecation rule did not add smoke failures in the current fixture set.
