### PR TITLE
Add plugin corpus batch analysis

### DIFF
--- a/.agents/skills/clawhub-batch-analysis/SKILL.md
+++ b/.agents/skills/clawhub-batch-analysis/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: clawhub-batch-analysis
+description: Use when analyzing how Plugin Inspector rule, warning, deprecation, or compatibility changes affect the ClawHub plugin corpus. Guides agents to export plugins from ClawHub, run `plugin-inspector batch`, and summarize affected plugins and finding frequency.
+---
+
+# ClawHub Batch Analysis
+
+Use this skill when a maintainer working on `@openclaw/plugin-inspector` wants to answer:
+
+- "If we deprecate this API, how many ClawHub plugins are affected?"
+- "Which plugins would receive this new warning/error?"
+- "What are the most common Plugin Inspector findings across exported ClawHub plugins?"
+
+## Workflow
+
+1. **Confirm the ClawHub export route**
+   - In the ClawHub repo, verify the current `/api/v1/plugins/export` contract before using it.
+   - Prefer a local or staging ClawHub target unless the user explicitly asks for production.
+   - Check auth requirements and pagination headers such as `X-Next-Cursor` in the current ClawHub code.
+
+2. **Export the plugin corpus**
+   - Request ZIP exports from `/api/v1/plugins/export`.
+   - Include both plugin families unless the user requests a narrower slice:
+     - `family=code-plugin`
+     - `family=bundle-plugin`
+   - If the endpoint is paginated, follow `X-Next-Cursor` until exhausted.
+   - Store raw export ZIPs and an export manifest in a temp or ignored working directory.
+
+3. **Unpack safely**
+   - Unpack into a fresh directory.
+   - Do not execute plugin code during unpacking.
+   - Keep any ClawHub export metadata near the unpacked corpus so plugin names/owners can be traced.
+
+4. **Run Plugin Inspector batch**
+   - From the `plugin-inspector` repo:
+
+```bash
+plugin-inspector batch /path/to/unpacked-clawhub-export \
+  --no-openclaw \
+  --out reports/clawhub-batch-analysis \
+  --concurrency 8 \
+  --json
+```
+
+   - Use `--openclaw <path>` instead of `--no-openclaw` when validating against a local OpenClaw checkout or a branch with new compatibility metadata.
+   - Add `--keep-plugin-reports` only when per-plugin artifacts are needed; large exports can produce many files.
+
+5. **Summarize impact**
+   - Lead with:
+     - total plugins scanned
+     - plugins with errors
+     - plugins with warnings
+     - top finding codes by affected plugin count
+   - Include affected plugin/version rows for the specific finding under investigation.
+   - Link or point to:
+     - `plugin-inspector-batch-report.json`
+     - `plugin-inspector-batch-report.md`
+
+## Safety Notes
+
+- Treat exported plugins as untrusted source. Do not pass `--runtime`, `--mock-sdk`, or `--allow-execute` unless the user explicitly requests runtime capture in an isolated workspace.
+- Keep production exports and reports out of git unless the user explicitly asks to publish a sanitized artifact.
+- If export counts or endpoint behavior matter, verify against live ClawHub instead of relying on memory.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Copy-ready examples live in:
 | `plugin-inspector config` | Print resolved plugin-root config as text or JSON. |
 | `plugin-inspector init` | Write starter config, scripts, and optional GitHub Actions workflow. |
 | `plugin-inspector report` | Run a fixture-suite config with many plugins. |
+| `plugin-inspector batch` | Discover plugin roots under a folder and write one aggregate impact report. |
 | `plugin-inspector capture` | Runtime-capture one entrypoint directly. |
 
 Common options:
@@ -404,6 +405,7 @@ Stable grouped facades:
 | `reports` | Render/write reports and classify issue findings. |
 | `contracts` | Build, render, validate, and write contract captures and coverage. |
 | `ci` | Build summaries, policy reports, execution results, SARIF, and JUnit outputs. |
+| `batch` | Discover plugin roots and aggregate compatibility findings across a corpus. |
 | `runtime` | Build runtime profiles, profile diffs, ref diffs, and import-loop profiles. |
 | `synthetic` | Build and run synthetic probe plans. |
 

--- a/src/batch.js
+++ b/src/batch.js
@@ -1,0 +1,296 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { renderMarkdownTable, writeJsonMarkdownArtifacts } from "./artifacts.js";
+import { runPluginCheck } from "./api.js";
+
+const ignoredDirs = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  "node_modules",
+  "reports",
+  "dist",
+  "build",
+  ".plugin-inspector",
+]);
+
+export async function runBatchAnalysis(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? options.inputDir ?? process.cwd());
+  const outDir = options.outDir ?? "reports";
+  const outRoot = path.resolve(rootDir, outDir);
+  const concurrency = Math.max(1, Math.min(Math.round(options.concurrency ?? 4), 32));
+  const keepPluginReports = options.keepPluginReports === true;
+  const pluginRoots = await discoverPluginRoots(rootDir);
+  const tempRoot = keepPluginReports ? null : await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-batch-"));
+  const entries = [];
+
+  try {
+    await runWithConcurrency(pluginRoots, concurrency, async (pluginRoot) => {
+      const reportsRoot = keepPluginReports
+        ? path.join(outRoot, "plugins", slugForPath(path.relative(rootDir, pluginRoot)))
+        : path.join(tempRoot, slugForPath(path.relative(rootDir, pluginRoot)));
+      entries.push(
+        await inspectBatchPlugin(pluginRoot, {
+          ...options,
+          rootDir,
+          outDir: reportsRoot,
+          openclawPath: options.openclawPath,
+        }),
+      );
+    });
+  } finally {
+    if (tempRoot) await rm(tempRoot, { recursive: true, force: true });
+  }
+
+  entries.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const report = buildBatchReport({
+    rootDir,
+    entries,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+  });
+  const paths = await writeBatchReport(report, { outDir: outRoot, check: options.checkArtifacts });
+  return { report, paths };
+}
+
+export async function discoverPluginRoots(rootDir) {
+  const roots = [];
+  await walk(path.resolve(rootDir));
+  roots.sort();
+  return roots;
+
+  async function walk(dir) {
+    if (await isPluginRoot(dir)) {
+      roots.push(dir);
+      return;
+    }
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || ignoredDirs.has(entry.name)) continue;
+      await walk(path.join(dir, entry.name));
+    }
+  }
+}
+
+export async function writeBatchReport(report, options = {}) {
+  return writeJsonMarkdownArtifacts({
+    jsonPath: path.join(options.outDir ?? "reports", "plugin-inspector-batch-report.json"),
+    markdownPath: path.join(options.outDir ?? "reports", "plugin-inspector-batch-report.md"),
+    json: report,
+    markdown: renderBatchMarkdown(report),
+    check: options.check,
+  });
+}
+
+function buildBatchReport({ rootDir, entries, generatedAt }) {
+  const findingFrequency = findingFrequencyRows(entries);
+  const summary = {
+    pluginCount: entries.length,
+    passed: entries.filter((entry) => entry.status === "pass").length,
+    failed: entries.filter((entry) => entry.status !== "pass").length,
+    pluginsWithErrors: entries.filter((entry) => entry.errorCount > 0).length,
+    pluginsWithWarnings: entries.filter((entry) => entry.warningCount > 0).length,
+    errorCount: entries.reduce((sum, entry) => sum + entry.errorCount, 0),
+    warningCount: entries.reduce((sum, entry) => sum + entry.warningCount, 0),
+    findingCodeCount: findingFrequency.length,
+  };
+  return {
+    generatedAt,
+    rootDir,
+    summary,
+    findingFrequency,
+    plugins: entries,
+  };
+}
+
+async function inspectBatchPlugin(pluginRoot, options) {
+  try {
+    const { report } = await runPluginCheck({
+      allowExecution: options.allowExecution,
+      capture: options.capture,
+      configPath: options.configPath,
+      mockSdk: options.mockSdk,
+      openclawPath: options.openclawPath,
+      outDir: options.outDir,
+      pluginRoot,
+    });
+    const findings = normalizeReportFindings(report);
+    return {
+      pluginRoot,
+      relativePath: path.relative(options.rootDir ?? process.cwd(), pluginRoot) || ".",
+      status: report.status,
+      packageName: packageNameFromReport(report),
+      targetOpenClaw: report.targetOpenClaw,
+      errorCount: findings.filter((finding) => finding.kind === "error").length,
+      warningCount: findings.filter((finding) => finding.kind === "warning").length,
+      findings,
+    };
+  } catch (error) {
+    return {
+      pluginRoot,
+      relativePath: path.relative(options.rootDir ?? process.cwd(), pluginRoot) || ".",
+      status: "error",
+      packageName: path.basename(pluginRoot),
+      targetOpenClaw: null,
+      errorCount: 1,
+      warningCount: 0,
+      findings: [
+        {
+          kind: "error",
+          code: "plugin-inspector-batch-failure",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
+  }
+}
+
+function normalizeReportFindings(report) {
+  return [
+    ...(report.breakages ?? []).map((finding) => normalizeFinding(finding, "error")),
+    ...(report.issues ?? []).map((finding) =>
+      normalizeFinding(
+        finding,
+        finding.status === "blocking" || finding.severity === "P0" ? "error" : "warning",
+      ),
+    ),
+    ...(report.warnings ?? []).map((finding) => normalizeFinding(finding, "warning")),
+    ...(report.suggestions ?? []).map((finding) => normalizeFinding(finding, "warning")),
+  ];
+}
+
+function normalizeFinding(finding, kind) {
+  return {
+    kind,
+    code: finding.code ?? "plugin-inspector-finding",
+    severity: finding.severity,
+    issueClass: finding.issueClass,
+    message: finding.message ?? finding.title ?? "See plugin report.",
+    evidence: finding.evidence,
+  };
+}
+
+function findingFrequencyRows(entries) {
+  const byCode = new Map();
+  for (const entry of entries) {
+    const seenForPlugin = new Set();
+    for (const finding of entry.findings) {
+      const current = byCode.get(finding.code) ?? {
+        code: finding.code,
+        count: 0,
+        plugins: 0,
+        errors: 0,
+        warnings: 0,
+      };
+      current.count += 1;
+      if (!seenForPlugin.has(finding.code)) {
+        current.plugins += 1;
+        seenForPlugin.add(finding.code);
+      }
+      if (finding.kind === "error") current.errors += 1;
+      else current.warnings += 1;
+      byCode.set(finding.code, current);
+    }
+  }
+  return [...byCode.values()].sort((a, b) => b.plugins - a.plugins || b.count - a.count);
+}
+
+function renderBatchMarkdown(report) {
+  return [
+    "# Plugin Inspector Batch Report",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Root: ${report.rootDir}`,
+    "",
+    "## Summary",
+    "",
+    renderMarkdownTable(
+      [
+        ["Plugins", report.summary.pluginCount],
+        ["Passed", report.summary.passed],
+        ["Failed", report.summary.failed],
+        ["Plugins with errors", report.summary.pluginsWithErrors],
+        ["Plugins with warnings", report.summary.pluginsWithWarnings],
+        ["Errors", report.summary.errorCount],
+        ["Warnings", report.summary.warningCount],
+      ],
+      ["Metric", "Value"],
+    ),
+    "",
+    "## Finding Frequency",
+    "",
+    report.findingFrequency.length
+      ? renderMarkdownTable(
+          report.findingFrequency.map((row) => [
+            row.code,
+            row.plugins,
+            row.count,
+            row.errors,
+            row.warnings,
+          ]),
+          ["Code", "Plugins", "Findings", "Errors", "Warnings"],
+        )
+      : "_No findings._",
+    "",
+    "## Plugins",
+    "",
+    report.plugins.length
+      ? renderMarkdownTable(
+          report.plugins.map((plugin) => [
+            plugin.packageName,
+            plugin.relativePath,
+            plugin.status,
+            plugin.errorCount,
+            plugin.warningCount,
+          ]),
+          ["Package", "Path", "Status", "Errors", "Warnings"],
+        )
+      : "_No plugin roots discovered._",
+  ].join("\n");
+}
+
+async function runWithConcurrency(items, concurrency, worker) {
+  let index = 0;
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (index < items.length) {
+      const item = items[index];
+      index += 1;
+      await worker(item);
+    }
+  });
+  await Promise.all(runners);
+}
+
+async function isPluginRoot(dir) {
+  if (existsSync(path.join(dir, "plugin-inspector.config.json"))) return true;
+  if (existsSync(path.join(dir, ".plugin-inspector.json"))) return true;
+  if (existsSync(path.join(dir, "openclaw.plugin.json"))) return true;
+  const packageJsonPath = path.join(dir, "package.json");
+  if (!existsSync(packageJsonPath)) return false;
+  try {
+    const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+    return Boolean(packageJson.openclaw || packageJson.pluginInspector || packageJson["plugin-inspector"]);
+  } catch {
+    return false;
+  }
+}
+
+function packageNameFromReport(report) {
+  return (
+    report.fixtures?.[0]?.package?.packageJson?.name ??
+    report.fixtures?.[0]?.package?.name ??
+    report.fixtures?.[0]?.name ??
+    report.fixtures?.[0]?.id ??
+    "plugin"
+  );
+}
+
+function slugForPath(value) {
+  return (
+    String(value)
+      .replaceAll(path.sep, "-")
+      .replace(/[^a-zA-Z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "plugin"
+  );
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   loadPluginConfig,
   renderTextSummary,
+  runBatchAnalysis,
   sanitizeReportArtifact,
   runPluginCheck,
 } from "./index.js";
@@ -43,6 +44,8 @@ try {
     }
   } else if (command === "ci") {
     await runCi(commandArgs);
+  } else if (command === "batch") {
+    await runBatch(commandArgs);
   } else if (command === "capture") {
     await runCapture(commandArgs);
   } else {
@@ -51,6 +54,36 @@ try {
 } catch (error) {
   console.error(error.message);
   process.exitCode = 1;
+}
+
+async function runBatch(commandArgs) {
+  const inputDir = readFirstPositional(commandArgs, new Set(["--out", "--openclaw", "--concurrency"]));
+  const outDir = readFlag(commandArgs, "--out") ?? "reports";
+  const openclawPath = commandArgs.includes("--no-openclaw") ? false : readFlag(commandArgs, "--openclaw");
+  const concurrency = Number(readFlag(commandArgs, "--concurrency") ?? "4");
+  const json = commandArgs.includes("--json");
+  const check = commandArgs.includes("--check");
+  const keepPluginReports = commandArgs.includes("--keep-plugin-reports");
+  if (!inputDir) {
+    throw new Error("batch requires a folder of plugin roots");
+  }
+  const { report, paths } = await runBatchAnalysis({
+    rootDir: inputDir,
+    outDir,
+    openclawPath,
+    concurrency,
+    keepPluginReports,
+  });
+
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderBatchTextSummary(report, paths));
+  }
+
+  if (check && report.summary.pluginsWithErrors > 0) {
+    throw new Error(`plugin-inspector batch found ${report.summary.pluginsWithErrors} plugin(s) with errors`);
+  }
 }
 
 async function runConfig(commandArgs) {
@@ -326,6 +359,34 @@ function renderCiTextSummary(summary) {
   ].join("\n");
 }
 
+function renderBatchTextSummary(report, paths) {
+  const lines = [
+    "Plugin Inspector Batch",
+    `Plugins: ${report.summary.pluginCount}`,
+    `Plugins with errors: ${report.summary.pluginsWithErrors}`,
+    `Plugins with warnings: ${report.summary.pluginsWithWarnings}`,
+    `Finding codes: ${report.summary.findingCodeCount}`,
+    "",
+    "Reports:",
+    `- JSON: ${paths.jsonPath}`,
+    `- Markdown: ${paths.markdownPath}`,
+  ];
+  const topFinding = report.findingFrequency[0];
+  if (topFinding) {
+    lines.push("", `Top finding: ${topFinding.code} (${topFinding.plugins} plugin(s))`);
+  }
+  return lines.join("\n");
+}
+
+function readFirstPositional(args, valueFlags = new Set()) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("-")) return arg;
+    if (valueFlags.has(arg)) index += 1;
+  }
+  return undefined;
+}
+
 function initCommandSummary(result) {
   return {
     dryRun: result.dryRun,
@@ -357,6 +418,7 @@ Usage:
   plugin-inspector config [--plugin-root <path>] [--config <path>] [--json]
   plugin-inspector init [--plugin-root <path>] [--config <path>] [--ci] [--scripts] [--package-manager npm|pnpm|yarn|bun] [--dry-run] [--json] [--force]
   plugin-inspector report --config <path> [--out <dir>] [--check] [--json]
+  plugin-inspector batch <folder> [--out <dir>] [--openclaw <path>] [--no-openclaw] [--concurrency <n>] [--keep-plugin-reports] [--check] [--json]
   plugin-inspector inspect [--plugin-root <path>] [--config <path>] [--out <dir>] [--check] [--json] [--sarif [path]] [--junit [path]] [--allow-execute]
   plugin-inspector ci [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path>] [--no-openclaw] [--runtime] [--mock-sdk|--real-sdk] [--allow-execute] [--json] [--no-sarif] [--no-junit]
   plugin-inspector capture <entrypoint> [--mock-sdk|--real-sdk] [--allow-execute] [--plugin-root <path>] [--output <path>]

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import * as runtimeReconciliationApi from "./runtime-reconciliation.js";
 import * as syntheticEntrypointApi from "./synthetic-entrypoint.js";
 import * as syntheticProbeSuiteApi from "./synthetic-probe-suite.js";
 import * as syntheticProbesApi from "./synthetic-probes.js";
+import * as batchApi from "./batch.js";
 
 export const pluginRoot = Object.freeze({
   loadConfig: pluginApi.loadPluginConfig,
@@ -24,6 +25,12 @@ export const pluginRoot = Object.freeze({
   runCheck: pluginApi.runPluginCheck,
   captureEntrypoint: pluginApi.capturePluginEntrypoint,
   setup: pluginApi.setupPluginInspector,
+});
+
+export const batch = Object.freeze({
+  discoverPluginRoots: batchApi.discoverPluginRoots,
+  run: batchApi.runBatchAnalysis,
+  writeReport: batchApi.writeBatchReport,
 });
 
 export const fixtureSuites = Object.freeze({
@@ -131,6 +138,11 @@ export const synthetic = Object.freeze({
   defaultRegistrationArguments: syntheticProbesApi.defaultSyntheticRegistrationArguments,
 });
 
+export {
+  discoverPluginRoots,
+  runBatchAnalysis,
+  writeBatchReport,
+} from "./batch.js";
 export {
   capturePluginEntrypoint,
   buildFixtureSetColdImportReadiness,

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -300,6 +300,87 @@ test("init command can print a JSON summary", async () => {
   ]);
 });
 
+test("batch command scans plugin roots and writes aggregate impact reports", async () => {
+  const corpusDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-cli-batch-corpus-"));
+  const goodRoot = await createCliPluginRoot("plugin-inspector-cli-batch-good-");
+  const brokenRoot = await createCliPluginRoot("plugin-inspector-cli-batch-broken-");
+  await mkdir(path.join(corpusDir, "plugins"), { recursive: true });
+  await copyPluginRoot(goodRoot, path.join(corpusDir, "plugins", "good-plugin"));
+  await copyPluginRoot(brokenRoot, path.join(corpusDir, "plugins", "broken-plugin"));
+  await writeFile(
+    path.join(corpusDir, "plugins", "broken-plugin", "plugin-inspector.config.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        plugin: {
+          id: "broken-plugin",
+          priority: "high",
+          sourceRoot: "src",
+          expect: { registrations: ["registerMissingTool"] },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  const cliPath = path.resolve("src/cli.js");
+
+  const { stdout } = await execFileAsync(process.execPath, [
+    cliPath,
+    "batch",
+    corpusDir,
+    "--out",
+    "batch-reports",
+    "--no-openclaw",
+    "--json",
+  ]);
+  const jsonPath = path.join(corpusDir, "batch-reports", "plugin-inspector-batch-report.json");
+  const markdownPath = path.join(corpusDir, "batch-reports", "plugin-inspector-batch-report.md");
+  const stdoutReport = JSON.parse(stdout);
+  const artifactReport = JSON.parse(await readFile(jsonPath, "utf8"));
+  const markdown = await readFile(markdownPath, "utf8");
+
+  assert.equal(stdoutReport.summary.pluginCount, 2);
+  assert.equal(artifactReport.summary.pluginCount, 2);
+  assert.equal(artifactReport.summary.pluginsWithErrors, 1);
+  const missingSeam = artifactReport.findingFrequency.find(
+    (finding) => finding.code === "missing-expected-seam",
+  );
+  assert.equal(missingSeam.plugins, 1);
+  assert.deepEqual(
+    artifactReport.plugins.map((plugin) => plugin.packageName).sort(),
+    ["@example/openclaw-weather", "@example/openclaw-weather"],
+  );
+  assert.match(markdown, /# Plugin Inspector Batch Report/);
+  assert.match(markdown, /missing-expected-seam/);
+  await assert.rejects(
+    () =>
+      execFileAsync(process.execPath, [
+        cliPath,
+        "batch",
+        "--out",
+        "check-reports",
+        "--no-openclaw",
+        "--check",
+        corpusDir,
+      ]),
+    (error) => {
+      assert.match(error.stderr, /plugin-inspector batch found 1 plugin\(s\) with errors/);
+      return true;
+    },
+  );
+});
+
+test("clawhub batch analysis skill documents export plus batch workflow", async () => {
+  const skill = await readFile(path.resolve(".agents/skills/clawhub-batch-analysis/SKILL.md"), "utf8");
+
+  assert.match(skill, /^name: clawhub-batch-analysis/m);
+  assert.match(skill, /\/api\/v1\/plugins\/export/);
+  assert.match(skill, /plugin-inspector batch/);
+  assert.match(skill, /finding frequency/i);
+});
+
 async function createCliPluginRoot(prefix) {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), prefix));
   await mkdir(path.join(rootDir, "src"), { recursive: true });
@@ -336,6 +417,18 @@ async function createCliPluginRoot(prefix) {
     "utf8",
   );
   return rootDir;
+}
+
+async function copyPluginRoot(sourceDir, targetDir) {
+  await mkdir(path.join(targetDir, "src"), { recursive: true });
+  for (const file of ["package.json", "openclaw.plugin.json", "plugin-inspector.config.json"]) {
+    await writeFile(path.join(targetDir, file), await readFile(path.join(sourceDir, file), "utf8"), "utf8");
+  }
+  await writeFile(
+    path.join(targetDir, "src", "index.js"),
+    await readFile(path.join(sourceDir, "src", "index.js"), "utf8"),
+    "utf8",
+  );
 }
 
 async function createTargetOpenClaw(rootDir) {


### PR DESCRIPTION
## Summary
- add `plugin-inspector batch <folder>` to discover exported plugin roots and aggregate inspector findings across a corpus
- expose batch helpers through the public API facade and document the CLI/API surface
- add the `clawhub-batch-analysis` repo skill for exporting ClawHub plugins and running batch impact analysis safely

## Validation
- `node --test --test-name-pattern "batch command|clawhub batch" test/cli.test.js`
- `npm run release:contents`
- live smoke: exported one authenticated production ClawHub plugin page and ran `node src/cli.js batch <unpacked-export> --no-openclaw --check`; warnings were reported and `--check` exited 0

## Notes
- `npm test` was run on the PR branch and passed the new batch tests, but one unrelated `mock SDK windows spawn helpers return concrete invocations` test failed in the full run. The same test passed when rerun in isolation with `node --test --test-name-pattern "mock SDK windows spawn helpers return concrete invocations" test/synthetic-probes.test.js`.
