### PR TITLE
fix(workspace-plan): install build dependencies

### DIFF
--- a/src/workspace-plan.js
+++ b/src/workspace-plan.js
@@ -361,6 +361,7 @@ function requiredCapabilitiesFor(entrypoint, packageSummary = {}) {
     }
     if (blocker.code === "build-required") {
       capabilities.add("build");
+      capabilities.add("dependency-install");
     }
     if (blocker.code === "ts-loader-required") {
       capabilities.add("ts-loader");

--- a/test/workspace-plan.test.js
+++ b/test/workspace-plan.test.js
@@ -56,8 +56,8 @@ test("workspace plan maps blocked entrypoints to opt-in install/build/capture st
   assert.equal(plan.optIn.env, "TEST_EXEC=1");
   assert.equal(plan.summary.entrypointCount, 2);
   assert.equal(plan.summary.artifactStepCount, 2);
-  assert.equal(plan.summary.installStepCount, 1);
-  assert.equal(plan.summary.auditStepCount, 1);
+  assert.equal(plan.summary.installStepCount, 2);
+  assert.equal(plan.summary.auditStepCount, 2);
   assert.equal(plan.summary.pruneDevWorkspaceDependencyStepCount, 1);
   assert.equal(plan.summary.buildStepCount, 1);
   assert.equal(plan.summary.captureStepCount, 2);
@@ -87,6 +87,9 @@ test("workspace plan maps blocked entrypoints to opt-in install/build/capture st
   const buildEntrypoint = plan.fixtures[0].entrypoints.find((item) => item.packageName === "build-fixture");
   assert.ok(buildEntrypoint);
   assert.ok(buildEntrypoint.requiredCapabilities.includes("build"));
+  assert.ok(buildEntrypoint.requiredCapabilities.includes("dependency-install"));
+  assert.ok(buildEntrypoint.steps.some((step) => step.kind === "install" && step.command === "npm install --ignore-scripts"));
+  assert.ok(buildEntrypoint.steps.some((step) => step.kind === "audit" && step.command.includes("npm audit --json")));
   assert.ok(buildEntrypoint.steps.some((step) => step.kind === "build" && step.command === "npm run build"));
   assert.match(renderWorkspacePlanMarkdown(plan), /Entrypoint Workspaces/);
 });


### PR DESCRIPTION
## Summary

- install and audit isolated dependencies before running a plugin build for a missing generated entrypoint
- cover build-only entrypoints in the workspace-plan contract tests

## Verification

- `node --test test/workspace-plan.test.js`
- `autoreview --mode local --parallel-tests 'node --test test/workspace-plan.test.js'`
