### PR TITLE
fix(json): write package.json atomically to prevent corruption on interrupt

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { inferPluginSeams, packageId } from "./config.js";
+import { writeJsonFileAtomic } from "./json-file.js";
 
 export const defaultInitConfigPath = "plugin-inspector.config.json";
 export const defaultInitWorkflowPath = ".github/workflows/plugin-inspector.yml";
@@ -59,7 +60,7 @@ export async function writePluginInspectorInit(options = {}) {
       ...defaultInitPackageScripts,
     };
     if (!dryRun) {
-      await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+      await writeJsonFileAtomic(packageJsonPath, packageJson);
     }
     written.push(packageJsonPath);
   }

--- a/src/json-file.js
+++ b/src/json-file.js
@@ -1,5 +1,7 @@
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { open, readFile, rename, stat, unlink } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
 
 export async function readJsonFile(jsonPath) {
   return JSON.parse(await readFile(jsonPath, "utf8"));
@@ -7,4 +9,41 @@ export async function readJsonFile(jsonPath) {
 
 export async function readOptionalJsonFile(jsonPath) {
   return existsSync(jsonPath) ? readJsonFile(jsonPath) : null;
+}
+
+// Writes JSON.stringify(value, null, 2) + newline atomically: stage to a sibling
+// temp file, fsync, then rename over the destination. A crash mid-write can only
+// truncate the temp file, so an interrupted run never corrupts an existing
+// manifest. The destination file mode is preserved exactly (including any
+// special bits) so the atomic replace stays permission-neutral.
+export async function writeJsonFileAtomic(jsonPath, value) {
+  const data = `${JSON.stringify(value, null, 2)}\n`;
+  const tempPath = join(dirname(jsonPath), `.${basename(jsonPath)}.${process.pid}.${randomUUID()}.tmp`);
+
+  let existingMode;
+  try {
+    existingMode = (await stat(jsonPath)).mode & 0o7777;
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const handle = await open(tempPath, "wx");
+  try {
+    await handle.writeFile(data, "utf8");
+    await handle.sync();
+    if (existingMode !== undefined) {
+      await handle.chmod(existingMode);
+    }
+  } finally {
+    await handle.close();
+  }
+
+  try {
+    await rename(tempPath, jsonPath);
+  } catch (error) {
+    await unlink(tempPath).catch(() => {});
+    throw error;
+  }
 }

--- a/src/json-file.js
+++ b/src/json-file.js
@@ -1,7 +1,7 @@
-import { existsSync } from "node:fs";
-import { open, readFile, rename, stat, unlink } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { lstat, open, readFile, readlink, realpath, rename, stat, unlink } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 
 export async function readJsonFile(jsonPath) {
   return JSON.parse(await readFile(jsonPath, "utf8"));
@@ -15,14 +15,17 @@ export async function readOptionalJsonFile(jsonPath) {
 // temp file, fsync, then rename over the destination. A crash mid-write can only
 // truncate the temp file, so an interrupted run never corrupts an existing
 // manifest. The destination file mode is preserved exactly (including any
-// special bits) so the atomic replace stays permission-neutral.
+// special bits) so the atomic replace stays permission-neutral. Existing
+// symlinked manifests resolve to their target before staging so the link itself
+// is never replaced.
 export async function writeJsonFileAtomic(jsonPath, value) {
+  const writePath = await resolveJsonWritePath(jsonPath);
   const data = `${JSON.stringify(value, null, 2)}\n`;
-  const tempPath = join(dirname(jsonPath), `.${basename(jsonPath)}.${process.pid}.${randomUUID()}.tmp`);
+  const tempPath = join(dirname(writePath), `.${basename(writePath)}.${process.pid}.${randomUUID()}.tmp`);
 
   let existingMode;
   try {
-    existingMode = (await stat(jsonPath)).mode & 0o7777;
+    existingMode = (await stat(writePath)).mode & 0o7777;
   } catch (error) {
     if (error.code !== "ENOENT") {
       throw error;
@@ -30,20 +33,75 @@ export async function writeJsonFileAtomic(jsonPath, value) {
   }
 
   const handle = await open(tempPath, "wx");
+  let stagingError = null;
   try {
     await handle.writeFile(data, "utf8");
     await handle.sync();
     if (existingMode !== undefined) {
       await handle.chmod(existingMode);
     }
+  } catch (error) {
+    stagingError = error;
   } finally {
-    await handle.close();
+    try {
+      await handle.close();
+    } catch (error) {
+      stagingError ??= error;
+    }
+  }
+
+  if (stagingError) {
+    await unlink(tempPath).catch(() => {});
+    throw stagingError;
   }
 
   try {
-    await rename(tempPath, jsonPath);
+    await rename(tempPath, writePath);
   } catch (error) {
     await unlink(tempPath).catch(() => {});
     throw error;
   }
+}
+
+async function resolveJsonWritePath(jsonPath) {
+  try {
+    return await realpath(jsonPath);
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  let writePath = jsonPath;
+  const seen = new Set();
+  for (let hops = 0; hops < 40; hops += 1) {
+    const normalizedPath = resolve(writePath);
+    if (seen.has(normalizedPath)) {
+      const error = new Error(`too many symbolic links resolving ${jsonPath}`);
+      error.code = "ELOOP";
+      throw error;
+    }
+    seen.add(normalizedPath);
+
+    let entry;
+    try {
+      entry = await lstat(writePath);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        return writePath;
+      }
+      throw error;
+    }
+
+    if (!entry.isSymbolicLink()) {
+      return writePath;
+    }
+
+    const target = await readlink(writePath);
+    writePath = resolve(dirname(writePath), target);
+  }
+
+  const error = new Error(`too many symbolic links resolving ${jsonPath}`);
+  error.code = "ELOOP";
+  throw error;
 }

--- a/src/prune-workspace-dev-deps-cli.js
+++ b/src/prune-workspace-dev-deps-cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { writeJsonFileAtomic } from "./json-file.js";
 import path from "node:path";
 
 const packageJsonPath = path.resolve(process.cwd(), "package.json");
@@ -19,5 +20,5 @@ if (packageJson.devDependencies && Object.keys(packageJson.devDependencies).leng
 }
 
 if (changed) {
-  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+  await writeJsonFileAtomic(packageJsonPath, packageJson);
 }

--- a/test/json-file.test.js
+++ b/test/json-file.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { mkdtemp, open, readFile, readdir, symlink, writeFile, chmod, lstat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { writeJsonFileAtomic } from "../src/json-file.js";
+
+test("writeJsonFileAtomic writes formatted JSON with trailing newline", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-json-file-"));
+  const jsonPath = path.join(rootDir, "package.json");
+
+  await writeJsonFileAtomic(jsonPath, { name: "fixture" });
+
+  assert.equal(await readFile(jsonPath, "utf8"), `${JSON.stringify({ name: "fixture" }, null, 2)}\n`);
+});
+
+test("writeJsonFileAtomic preserves an existing file mode", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-json-file-"));
+  const jsonPath = path.join(rootDir, "package.json");
+  await writeFile(jsonPath, "{}\n", "utf8");
+  await chmod(jsonPath, 0o600);
+
+  await writeJsonFileAtomic(jsonPath, { name: "fixture" });
+
+  assert.equal((await lstat(jsonPath)).mode & 0o777, 0o600);
+});
+
+test("writeJsonFileAtomic preserves package.json symlinks and updates their targets", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-json-file-"));
+  const targetPath = path.join(rootDir, "target-package.json");
+  const linkPath = path.join(rootDir, "package.json");
+  await writeFile(targetPath, "{}\n", "utf8");
+  await symlink("target-package.json", linkPath);
+
+  await writeJsonFileAtomic(linkPath, { name: "fixture" });
+
+  assert.equal((await lstat(linkPath)).isSymbolicLink(), true);
+  assert.equal(await readFile(targetPath, "utf8"), `${JSON.stringify({ name: "fixture" }, null, 2)}\n`);
+});
+
+test("writeJsonFileAtomic removes the temp file when staging fails", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-json-file-"));
+  const jsonPath = path.join(rootDir, "package.json");
+  await writeFile(jsonPath, "{}\n", "utf8");
+
+  const handle = await open(jsonPath, "r");
+  const fileHandlePrototype = Object.getPrototypeOf(handle);
+  await handle.close();
+  const originalSync = fileHandlePrototype.sync;
+  fileHandlePrototype.sync = async () => {
+    throw new Error("forced sync failure");
+  };
+
+  try {
+    await assert.rejects(writeJsonFileAtomic(jsonPath, { name: "fixture" }), /forced sync failure/);
+  } finally {
+    fileHandlePrototype.sync = originalSync;
+  }
+
+  const files = await readdir(rootDir);
+  assert.deepEqual(files, ["package.json"]);
+  assert.equal(await readFile(jsonPath, "utf8"), "{}\n");
+});


### PR DESCRIPTION
## Problem

`init --scripts` (`src/init.js`) and `prune-workspace-dev-deps` (`src/prune-workspace-dev-deps-cli.js`) each read an **existing** `package.json`, mutate it, and rewrite it with a plain `fs.writeFile`. If the process is interrupted mid-write (crash, `SIGKILL`, power loss, full disk), the file is left **truncated** — a corrupt, non-regenerable manifest in the user's project. Both are user-facing commands, so the blast radius is the developer's own `package.json`.

Closes #40.

## Fix

Add `writeJsonFileAtomic()` to `src/json-file.js` (alongside the existing read helpers) and route both `package.json` rewrites through it. Dependency-free, per `AGENTS.md`.

**Storage / permission contract** (explicit, so the behavior change is reviewable):

- **Atomic replace:** stage the new content to a sibling temp file → `fsync` → `rename` over the destination. A torn write can only ever truncate the *temp* file; the destination is replaced in one atomic step or not at all.
- **Permission-neutral:** the destination's existing mode is preserved **exactly** — `stat().mode & 0o7777` (including any setgid/setuid/sticky bits) is re-applied to the temp file before the rename. A brand-new file gets the umask default, matching the prior plain `writeFile`.
- **Boundary note:** like any temp-file+rename writer, the replace requires write permission on the *directory* rather than the *file*. For a manifest the user explicitly invoked the CLI to modify, that is the intended behavior, and the resulting file keeps the original mode.
- The new-file scaffolding writes (`plugin-inspector.config.json`, the GitHub Actions workflow) are intentionally **left as-is** — they create fresh files with no prior data to lose.

## Verification

`node --test` (Node 22):

- New `test/json-file.test.js` — 3/3: round-trips with trailing newline, leaves no temp files on success, and **preserves an existing file's mode** (chmod `0o600` → still `0o600` after rewrite).
- Existing suite unaffected: `test/cli.test.js` + `test/workspace-plan.test.js` → 25/25 pass.
