### PR TITLE
Release plugin-inspector 0.3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.17 - 2026-06-29
+
 ### Fixed
 
 - Detect deprecated session SDK read/write, file-path, and transcript helpers across source files, packaged `dist`/`build` artifacts, runtime session APIs, and dynamic SDK imports.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "private": false,
   "description": "Offline compatibility inspector for OpenClaw plugins.",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `@openclaw/plugin-inspector` to 0.3.17.
- Move the session SDK deprecation coverage changelog entry into the 0.3.17 release section.

## Proof

- `npm run release:contents`
- `node scripts/release-notes.mjs 0.3.17`

