### PR TITLE
fix: order synthetic gateway lifecycle probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Run synthetic gateway lifecycle hooks around ordinary probes while preserving capture indexes and report order, so `gateway_stop` teardown cannot invalidate later compatibility checks.
+
 ## 0.3.17 - 2026-06-29
 
 ### Fixed

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -591,23 +591,37 @@ export async function runCapturedSyntheticProbes(capture, options = {}) {
   const hookContexts = options.hookContexts ?? defaultSyntheticHookContexts;
   const captured = capture.captured ?? [];
   const retained = new Map((capture.retained ?? []).map((item) => [item.captureIndex, item]));
-  const results = [];
+  const resultsByCaptureIndex = new Map();
+  const executionEntries = captured
+    .map((entry, captureIndex) => ({ entry, captureIndex }))
+    .sort(
+      (left, right) =>
+        syntheticLifecyclePhase(left.entry) - syntheticLifecyclePhase(right.entry) ||
+        left.captureIndex - right.captureIndex,
+    );
 
-  for (let index = 0; index < captured.length; index += 1) {
-    const entry = captured[index];
-    const retainedEntry = retained.get(index);
+  for (const { entry, captureIndex } of executionEntries) {
+    const retainedEntry = retained.get(captureIndex);
     if (!retainedEntry) {
-      results.push(blockedResult(entry, index, "handler retention was not enabled"));
+      resultsByCaptureIndex.set(captureIndex, [blockedResult(entry, captureIndex, "handler retention was not enabled")]);
       continue;
     }
     if (entry.kind === "hook") {
-      results.push(await runHookProbe(entry, retainedEntry, index, { hookEvents, hookContexts }));
+      resultsByCaptureIndex.set(captureIndex, [
+        await runHookProbe(entry, retainedEntry, captureIndex, { hookEvents, hookContexts }),
+      ]);
       continue;
     }
     if (entry.kind === "registration") {
-      results.push(...(await runRegistrationProbes(entry, retainedEntry, index, options)));
+      resultsByCaptureIndex.set(
+        captureIndex,
+        await runRegistrationProbes(entry, retainedEntry, captureIndex, options),
+      );
     }
   }
+  // Execute in lifecycle order, but keep report rows and captureIndex values
+  // stable for downstream consumers that compare artifacts across runs.
+  const results = captured.flatMap((_, captureIndex) => resultsByCaptureIndex.get(captureIndex) ?? []);
 
   return {
     entrypoint: capture.entrypoint,
@@ -620,6 +634,19 @@ export async function runCapturedSyntheticProbes(capture, options = {}) {
     },
     results,
   };
+}
+
+function syntheticLifecyclePhase(entry) {
+  if (entry.kind !== "hook") {
+    return 1;
+  }
+  if (entry.name === "gateway_start") {
+    return 0;
+  }
+  if (entry.name === "gateway_stop") {
+    return 2;
+  }
+  return 1;
 }
 
 export function renderSyntheticProbeMarkdown(plan, options = {}) {

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -219,6 +219,48 @@ test("synthetic probes invoke retained hook and tool handlers", async () => {
   );
 });
 
+test("synthetic probes execute gateway lifecycle around ordinary probes without reordering results", async () => {
+  const capture = await captureLocalFixture([
+    "let started = false;",
+    "let ordinaryProbeCount = 0;",
+    "export function register(api) {",
+    "  api.on('gateway_stop', () => {",
+    "    if (!started || ordinaryProbeCount !== 2) throw new Error('gateway stopped before ordinary probes');",
+    "    started = false;",
+    "  });",
+    "  api.on('before_reset', () => {",
+    "    if (!started) throw new Error('ordinary hook ran outside gateway lifecycle');",
+    "    ordinaryProbeCount += 1;",
+    "  });",
+    "  api.registerCommand({",
+    "    name: 'fixture-command',",
+    "    handler() {",
+    "      if (!started) throw new Error('registration ran outside gateway lifecycle');",
+    "      ordinaryProbeCount += 1;",
+    "    },",
+    "  });",
+    "  api.on('gateway_start', () => {",
+    "    if (started) throw new Error('gateway started twice');",
+    "    started = true;",
+    "  });",
+    "}",
+  ]);
+
+  const result = await runCapturedSyntheticProbes(capture);
+
+  assert.equal(result.summary.failCount, 0);
+  assert.equal(result.summary.blockedCount, 0);
+  assert.deepEqual(
+    result.results.map((item) => [item.captureIndex, item.label]),
+    [
+      [0, "gateway_stop"],
+      [1, "before_reset"],
+      [2, "registerCommand.handler"],
+      [3, "gateway_start"],
+    ],
+  );
+});
+
 test("synthetic probes pass registrar-specific handler inputs", async () => {
   const capture = await captureLocalFixture([
     "export function register(api) {",


### PR DESCRIPTION
## Summary

- run `gateway_start` before ordinary synthetic probes
- run `gateway_stop` after ordinary synthetic probes
- preserve capture indexes and report ordering for downstream consumers

## Why

Plugins may register teardown hooks before ordinary hooks and commands. Executing strictly in capture order can tear down plugin state before later probes, producing false failures. This was reproducible against Crabpot's pinned Lossless Claw fixture.

## Proof

- `npm run check`: 204 tests pass; package contents pass
- packed-package source-blind contract: lifecycle order passes; missing-start anti-check fails as expected
- Crabpot Lossless Claw against `openclaw@2026.6.10`: 10 probes, 6 pass, 0 fail, 4 intentionally blocked
- autoreview focused tests: 15 pass

Related: openclaw/crabpot#173
