### PR TITLE
test(report-sanitizer): cover sanitizeReportArtifact path-redaction branches

### DIFF
--- a/test/report-sanitizer.test.js
+++ b/test/report-sanitizer.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { sanitizeReportArtifact } from "../src/report-sanitizer.js";
+
+test("returns the same report untouched when no absolute OpenClaw paths are present", () => {
+  const report = {
+    targetOpenClaw: { configuredPath: "../relative/openclaw", searchedPaths: ["also/relative"] },
+    issues: [{ title: "kept ../relative/openclaw" }],
+  };
+
+  const result = sanitizeReportArtifact(report);
+
+  // No absolute path => the original object is returned by reference, unmodified.
+  assert.equal(result, report);
+  assert.equal(result.targetOpenClaw.configuredPath, "../relative/openclaw");
+  assert.deepEqual(result.targetOpenClaw.searchedPaths, ["also/relative"]);
+  assert.equal(result.issues[0].title, "kept ../relative/openclaw");
+});
+
+test("does not mutate the input report and clones nested values", () => {
+  const report = {
+    targetOpenClaw: { configuredPath: "/home/user/openclaw", searchedPaths: [] },
+    issues: [{ evidence: ["/home/user/openclaw/logs"] }],
+  };
+
+  const result = sanitizeReportArtifact(report);
+
+  assert.notEqual(result, report);
+  // Input is left intact; only the returned clone is sanitized.
+  assert.equal(report.targetOpenClaw.configuredPath, "/home/user/openclaw");
+  assert.equal(report.issues[0].evidence[0], "/home/user/openclaw/logs");
+  assert.equal(result.targetOpenClaw.configuredPath, "<OPENCLAW_PATH>");
+  assert.equal(result.issues[0].evidence[0], "<OPENCLAW_PATH>/logs");
+});
+
+test("replaces the longest matching path first so nested paths never leak a suffix", () => {
+  const base = "/home/user/openclaw";
+  const nested = "/home/user/openclaw/extensions/telegram";
+  const report = {
+    targetOpenClaw: { configuredPath: base, searchedPaths: [nested] },
+    note: `loaded ${nested}/index.ts against ${base}`,
+  };
+
+  const result = sanitizeReportArtifact(report);
+
+  // Longest-first ordering is what prevents `${base}` from partially matching
+  // inside `${nested}` and leaving `/extensions/telegram` exposed.
+  assert.equal(result.note, "loaded <OPENCLAW_PATH>/index.ts against <OPENCLAW_PATH>");
+  assert.equal(result.targetOpenClaw.configuredPath, "<OPENCLAW_PATH>");
+  assert.deepEqual(result.targetOpenClaw.searchedPaths, ["<OPENCLAW_PATH>"]);
+});
+
+test("honors a custom openclawPathPlaceholder", () => {
+  const report = { targetOpenClaw: { configuredPath: "/srv/openclaw" }, note: "at /srv/openclaw" };
+
+  const result = sanitizeReportArtifact(report, { openclawPathPlaceholder: "[REDACTED]" });
+
+  assert.equal(result.targetOpenClaw.configuredPath, "[REDACTED]");
+  assert.equal(result.note, "at [REDACTED]");
+});
+
+test("detects Windows drive-letter and UNC absolute paths", () => {
+  const drivePath = "C:\\Users\\me\\openclaw";
+  const uncPath = "\\\\build-server\\share\\openclaw";
+  const report = {
+    targetOpenClaw: { configuredPath: drivePath, searchedPaths: [uncPath] },
+    note: `drive ${drivePath}\\logs and unc ${uncPath}\\logs`,
+  };
+
+  const result = sanitizeReportArtifact(report);
+
+  assert.equal(result.targetOpenClaw.configuredPath, "<OPENCLAW_PATH>");
+  assert.deepEqual(result.targetOpenClaw.searchedPaths, ["<OPENCLAW_PATH>"]);
+  assert.equal(result.note, "drive <OPENCLAW_PATH>\\logs and unc <OPENCLAW_PATH>\\logs");
+});
+
+test("ignores non-string and non-absolute searchedPaths entries", () => {
+  const report = {
+    targetOpenClaw: {
+      configuredPath: "/opt/openclaw",
+      searchedPaths: ["/opt/openclaw", "relative/openclaw", null, 42],
+    },
+    note: "found at /opt/openclaw but not relative/openclaw",
+  };
+
+  const result = sanitizeReportArtifact(report);
+
+  // Only the absolute string entries are sanitized; relative/non-string ones pass through.
+  assert.equal(result.note, "found at <OPENCLAW_PATH> but not relative/openclaw");
+  assert.equal(result.targetOpenClaw.configuredPath, "<OPENCLAW_PATH>");
+});


### PR DESCRIPTION
## What Problem This Solves

`src/report-sanitizer.js` exports `sanitizeReportArtifact(report, options)` — the redaction gate that strips absolute OpenClaw target paths out of every emitted report artifact (JSON via `--sanitize`, Markdown, issues, compatibility reports; re-exported through `src/index.js:238`, `src/report.js:308`, `src/advanced.js`, and `src/cli.js`). It shipped with **no direct test**. The only existing coverage exercises it indirectly through the report-writing happy path (`report.test.js:267`, `cli.test.js:90`), which always uses a **single** absolute path and the **default** placeholder — so the module's more subtle, security-relevant branches were unpinned:

- **Longest-path-first ordering.** `sensitiveOpenClawPaths` sorts matches by descending length before substring replacement. This is what stops a shorter path (e.g. `/home/user/openclaw`) from partially matching *inside* a longer one (`/home/user/openclaw/extensions/telegram`) and leaving the trailing `/extensions/telegram` **exposed** in the output. With only single-path coverage, reversing this sort would leak path suffixes and no test would catch it.
- **No-op passthrough.** When no absolute path is present the original report is returned **by reference**, unchanged — untested.
- **Custom `openclawPathPlaceholder`** option — untested (existing coverage only hits the default `<OPENCLAW_PATH>`).
- **Windows drive-letter + UNC absolute-path detection** (`isAbsolutePath`'s `C:\…` regex and `\\server\share` prefix) — untested; on POSIX `path.isAbsolute` returns false for these, so this branch is the *only* thing that redacts a Windows target path.
- **Non-string / relative `searchedPaths` filtering** — relative or non-string entries must pass through unredacted; untested.

A regression in any of these would silently weaken path redaction (a leak) or change the passthrough contract, and would ship green.

## Why This Change Was Made

Coverage-only. Adds one new file, `test/report-sanitizer.test.js` (+91), pinning the module's current `main` behavior against these branches. Tests import the **real** exported `sanitizeReportArtifact` from `../src/report-sanitizer.js` (matching the repo's per-module unit-test layout, e.g. `json-file.test.js`) and drive it directly — no stubs. **No production code is touched**; no new config, defaults, dependencies, or report field names (per AGENTS.md's "preserve stable report field names").

## User Impact

No user-visible or runtime change. For maintainers, the path-redaction gate now regresses loudly: a future edit that reverses the longest-first ordering (a path-suffix leak), drops the Windows/UNC detection, breaks the placeholder option, or changes the no-op passthrough will fail this suite instead of shipping silently.

## Evidence

Linux, Node 22.22, branched off current `main` (`2f93500`), no install needed (the suite runs the source directly via `node --test`).

**6/6 pass on clean `main`:**

```text
$ node --test test/report-sanitizer.test.js
# tests 6
# pass 6
# fail 0
```

**Full suite green with the new file — no regressions:**

```text
$ node --test test/*.test.js
# tests 212
# pass 212
# fail 0
```

**Non-vacuous — each scenario bites when its target branch is mutated** (mutation applied to `src/report-sanitizer.js`, suite re-run, then reverted):

| Mutation to `report-sanitizer.js` | Result |
| --- | --- |
| sort ascending (`left.length - right.length`) — reverses longest-first | 1 fail (nested-path leak) |
| remove the `sensitivePaths.length === 0` early return | 1 fail (passthrough identity) |
| force default placeholder (ignore `options.openclawPathPlaceholder`) | 1 fail (custom placeholder) |
| drop Windows/UNC detection (`return path.isAbsolute(value)` only) | 1 fail (drive/UNC) |
| *(reverted — control)* | **6 pass** |

Diff: **+91, one new test file, no production code.**

_AI-assisted contribution._

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUnh22xDcb5TNZ8Ac66tZH)_