### PR TITLE
refactor: remove unused isInspectorGapFinding export

### DIFF
--- a/src/issues.js
+++ b/src/issues.js
@@ -583,10 +583,6 @@ export function classifyIssueFinding(finding, targetOpenClaw, metadata = {}) {
   };
 }
 
-export function isInspectorGapFinding(finding, targetOpenClaw) {
-  return issueMetadata(finding, targetOpenClaw).issueClass === "inspector-gap";
-}
-
 export function isAuthorFacingFinding(finding, targetOpenClaw) {
   return Boolean(issueMetadata(finding, targetOpenClaw).authorRemediation);
 }


### PR DESCRIPTION
## What Problem This Solves

`src/issues.js` exports `isInspectorGapFinding(finding, targetOpenClaw)`, a one-line predicate, but nothing in the package uses it. A repo-wide search finds the symbol only at its own definition — zero call sites in `src`, `test`, `scripts`, `docs`, `examples`, or the README.

It is also not part of the published API surface. The `.` entry point (`src/index.js`) re-exports a specific, curated set of `issues.js` symbols — `classifyIssueFinding`, `issueId`, `isAuthorFacingFinding`, `knownIssueCodes` — and deliberately does **not** include this predicate. So `isInspectorGapFinding` is reachable from nothing, inside or outside the package.

The equivalent inspector-gap classification is still available where it's actually used: consumers derive it from the `issueClass === "inspector-gap"` field on a classified finding (e.g. `ci-policy.js`, `compatibility-report.js`), which is what this dead predicate wrapped.

## Why This Change Was Made

Debt cleanup: delete a fully-unreferenced exported function. Net-negative (−4 lines), behavior-preserving, single file.

**Scope boundary — what did NOT change:** no report field names or finding codes are touched (per `AGENTS.md`'s stable-field/code contract); no CLI, package entrypoint, or release metadata changes; the sibling predicate `isAuthorFacingFinding` and the shared `issueMetadata`/`classifyIssueFinding` helpers are untouched and still live.

## User Impact

None. No runtime, CLI, config, or public-API behavior changes — the removed symbol was reachable from nothing and was never re-exported through the package entry point.

## Evidence

Branched off current `main` (`b610d4e`), Linux, Node 22.22.2. The package has no dependencies, so the suite runs directly with `node --test`.

**Dead-code proof** — the symbol is referenced only at its own definition, so removing it leaves nothing dangling:

```
$ git grep -n isInspectorGapFinding        # on main, before removal
src/issues.js:586:export function isInspectorGapFinding(finding, targetOpenClaw) {

$ git grep -n isInspectorGapFinding        # after removal
(no output — zero references remain)
```

**Behavior preserved** — the full suite is green and the pass count is identical before and after (the removed symbol had no test, so the count is unchanged):

```
$ node --test test/*.test.js               # on main and on this branch
# tests 213
# pass 213
# fail 0
```

**What was not tested / limitations:** none beyond the above — this is a pure deletion of an unreferenced export with no reachable call path, so there is no runtime behavior to exercise. No new test file is added (there is nothing new to cover).

---

_AI-assisted contribution._


---
_Generated by [Claude Code](https://claude.ai/code/session_016NyLUL9Knbh1n6PQH6zBzm)_