### PR TITLE
build(deps): refresh GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -39,15 +39,15 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, plugin-inspector, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref }}
@@ -52,7 +52,7 @@ jobs:
           echo "RELEASE_VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Refresh generated and repository GitHub Actions workflows to the current checkout, setup-node, upload-artifact, and pnpm/action-setup releases.
+
 ## 0.3.18 - 2026-07-21
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
       - run: npm ci
       - run: npx @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: plugin-inspector-reports

--- a/examples/github-actions-code-scanning.yml
+++ b/examples/github-actions-code-scanning.yml
@@ -13,8 +13,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -24,7 +24,7 @@ jobs:
         if: always()
         with:
           sarif_file: reports/plugin-inspector.sarif
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: plugin-inspector-reports

--- a/examples/github-actions-plugin-inspector.yml
+++ b/examples/github-actions-plugin-inspector.yml
@@ -9,14 +9,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
       - run: npm ci
       - run: npx @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: plugin-inspector-reports

--- a/src/init.js
+++ b/src/init.js
@@ -108,14 +108,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: ${setup.cache}
 ${setup.corepack ? "      - run: corepack enable\n" : ""}      - run: ${setup.install}
       - run: ${setup.exec} @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: plugin-inspector-reports

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -396,6 +396,9 @@ test("init command writes plugin config and CI workflow", async () => {
   assert.equal(config.plugin.id, "weather");
   assert.equal(config.plugin.sourceRoot, "src");
   assert.equal(config.capture.mockSdk, true);
+  assert.match(workflow, /actions\/checkout@v7/);
+  assert.match(workflow, /actions\/setup-node@v7/);
+  assert.match(workflow, /actions\/upload-artifact@v7/);
   assert.match(workflow, /pnpm dlx @openclaw\/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute/);
 });
 


### PR DESCRIPTION
## Summary

- refresh repository workflows to `actions/checkout@v7`, `actions/setup-node@v7`, and `pnpm/action-setup@v6.0.9`
- emit the current checkout, setup-node, and upload-artifact v7 majors from `plugin-inspector init`
- keep README and checked-in workflow examples aligned with generated output
- add regression coverage for the generated action majors

## Verification

- `actionlint`
- `npm run check` — 213 tests plus package-contents validation
- generated a real npm-mode workflow with `plugin-inspector init --ci`, then passed it through `actionlint`
- `npm pack --dry-run --json` — 58 files, 396,653-byte package
- P1 autoreview — clean, no accepted/actionable findings
- Crabpot source-mode and published-package-mode smoke both produced the same 60-fixture report: 36 existing corpus breakages, byte-equivalent structured results after removing the timestamp

No runtime dependency was added; the package still has no npm dependencies or lockfile.
