### PR TITLE
fix: accept older minimum host compatibility floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Accept tested minimum OpenClaw host versions below a plugin's build version without reporting package metadata drift.
+
 ## 0.3.19 - 2026-07-27
 
 ### Highlights

--- a/src/fixture-summary.js
+++ b/src/fixture-summary.js
@@ -1270,21 +1270,28 @@ function parseSemver(value) {
   if (coreParts.some((part) => part.length > 1 && part.startsWith("0"))) {
     return null;
   }
-  const core = coreParts.map(Number);
-  if (core.some((part) => !Number.isSafeInteger(part))) {
-    return null;
-  }
   const prerelease = match[4]?.split(".") ?? [];
   if (prerelease.some((part) => /^[0-9]+$/.test(part) && part.length > 1 && part.startsWith("0"))) {
     return null;
   }
-  return { core, prerelease };
+  return { core: coreParts, prerelease };
+}
+
+function compareNumericIdentifier(left, right) {
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1;
+  }
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
 }
 
 function compareSemver(left, right) {
   for (let index = 0; index < left.core.length; index += 1) {
-    if (left.core[index] !== right.core[index]) {
-      return left.core[index] < right.core[index] ? -1 : 1;
+    const comparison = compareNumericIdentifier(left.core[index], right.core[index]);
+    if (comparison !== 0) {
+      return comparison;
     }
   }
   if (left.prerelease.length === 0 || right.prerelease.length === 0) {
@@ -1306,10 +1313,7 @@ function compareSemver(left, right) {
     const leftNumeric = /^[0-9]+$/.test(leftPart);
     const rightNumeric = /^[0-9]+$/.test(rightPart);
     if (leftNumeric && rightNumeric) {
-      if (leftPart.length !== rightPart.length) {
-        return leftPart.length < rightPart.length ? -1 : 1;
-      }
-      return leftPart < rightPart ? -1 : 1;
+      return compareNumericIdentifier(leftPart, rightPart);
     }
     if (leftNumeric !== rightNumeric) {
       return leftNumeric ? -1 : 1;

--- a/src/fixture-summary.js
+++ b/src/fixture-summary.js
@@ -1245,12 +1245,78 @@ function packageMinHostVersionDrift(packageSummary) {
   if (!nonEmptyString(openclaw?.install?.minHostVersion) || !nonEmptyString(openclaw?.buildOpenClawVersion)) {
     return false;
   }
-  return parseMinHostVersionFloor(openclaw.install.minHostVersion) !== openclaw.buildOpenClawVersion;
+  const minimumHostVersion = parseMinHostVersionFloor(openclaw.install.minHostVersion);
+  const buildOpenClawVersion = parseSemver(openclaw.buildOpenClawVersion);
+  if (!minimumHostVersion || !buildOpenClawVersion) {
+    return true;
+  }
+  return compareSemver(minimumHostVersion, buildOpenClawVersion) > 0;
 }
 
 function parseMinHostVersionFloor(value) {
   const match = /^>=([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/.exec(value);
-  return match?.[1] ?? null;
+  return match ? parseSemver(match[1]) : null;
+}
+
+function parseSemver(value) {
+  const match =
+    /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+      value,
+    );
+  if (!match) {
+    return null;
+  }
+  const coreParts = match.slice(1, 4);
+  if (coreParts.some((part) => part.length > 1 && part.startsWith("0"))) {
+    return null;
+  }
+  const core = coreParts.map(Number);
+  if (core.some((part) => !Number.isSafeInteger(part))) {
+    return null;
+  }
+  const prerelease = match[4]?.split(".") ?? [];
+  if (prerelease.some((part) => /^[0-9]+$/.test(part) && part.length > 1 && part.startsWith("0"))) {
+    return null;
+  }
+  return { core, prerelease };
+}
+
+function compareSemver(left, right) {
+  for (let index = 0; index < left.core.length; index += 1) {
+    if (left.core[index] !== right.core[index]) {
+      return left.core[index] < right.core[index] ? -1 : 1;
+    }
+  }
+  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+    if (left.prerelease.length === right.prerelease.length) {
+      return 0;
+    }
+    return left.prerelease.length === 0 ? 1 : -1;
+  }
+  const count = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = left.prerelease[index];
+    const rightPart = right.prerelease[index];
+    if (leftPart === undefined || rightPart === undefined) {
+      return leftPart === undefined ? -1 : 1;
+    }
+    if (leftPart === rightPart) {
+      continue;
+    }
+    const leftNumeric = /^[0-9]+$/.test(leftPart);
+    const rightNumeric = /^[0-9]+$/.test(rightPart);
+    if (leftNumeric && rightNumeric) {
+      if (leftPart.length !== rightPart.length) {
+        return leftPart.length < rightPart.length ? -1 : 1;
+      }
+      return leftPart < rightPart ? -1 : 1;
+    }
+    if (leftNumeric !== rightNumeric) {
+      return leftNumeric ? -1 : 1;
+    }
+    return leftPart < rightPart ? -1 : 1;
+  }
+  return 0;
 }
 
 function repoPathIncludedInNpmPack(packageSummary, repoPath) {

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -884,7 +884,7 @@ test("package contract classifier treats openclaw as a host-linked dependency", 
   );
 });
 
-test("package contract classifier reports broken install and release metadata", () => {
+test("package contract classifier accepts an older tested host floor", () => {
   const result = classifyPackageContracts({
     fixture: {
       id: "fixture",
@@ -931,9 +931,63 @@ test("package contract classifier reports broken install and release metadata", 
   });
 
   assert.ok(result.warnings.some((finding) => finding.code === "package-install-metadata-incomplete"));
-  assert.ok(result.warnings.some((finding) => finding.code === "package-min-host-version-drift"));
+  assert.equal(
+    result.warnings.some((finding) => finding.code === "package-min-host-version-drift"),
+    false,
+  );
   assert.ok(result.warnings.some((finding) => finding.code === "package-openclaw-unsupported-metadata"));
   assert.ok(result.decisions.some((decision) => decision.seam === "package-metadata"));
+});
+
+test("package contract classifier compares minimum host semver with the build version", () => {
+  const hasDriftWarning = (minHostVersion, buildOpenClawVersion) => {
+    const result = classifyPackageContracts({
+      fixture: {
+        id: "fixture",
+        path: "plugins/fixture",
+      },
+      inspection: {
+        registrations: ["registerTool"],
+      },
+      fixtureReport: {
+        pluginManifests: [{ version: "1.0.0" }],
+        package: {
+          path: "plugins/fixture/package.json",
+          name: "@openclaw/fixture-plugin",
+          version: "1.0.0",
+          dependencies: [],
+          peerDependencies: [],
+          optionalDependencies: [],
+          openclaw: {
+            compatPluginApi: "^1.0.0",
+            buildOpenClawVersion,
+            install: {
+              clawhubSpec: "clawhub:@openclaw/fixture-plugin",
+              npmSpec: "@openclaw/fixture-plugin",
+              defaultChoice: "clawhub",
+              minHostVersion,
+            },
+            release: {
+              publishToClawHub: true,
+              publishToNpm: true,
+            },
+            unsupportedMetadata: [],
+            entrypoints: [],
+          },
+        },
+      },
+    });
+    return result.warnings.some((finding) => finding.code === "package-min-host-version-drift");
+  };
+
+  assert.equal(hasDriftWarning(">=2026.7.1", "2026.7.1"), false);
+  assert.equal(hasDriftWarning(">=2026.6.5", "2026.7.1-2"), false);
+  assert.equal(hasDriftWarning(">=2026.7.1-1", "2026.7.1-2"), false);
+  assert.equal(hasDriftWarning(">=2026.7.1-2+build.1", "2026.7.1-2+build.2"), false);
+  assert.equal(hasDriftWarning(">=2026.7.1", "2026.7.1-2"), true);
+  assert.equal(hasDriftWarning(">=2026.7.2", "2026.7.1"), true);
+  assert.equal(hasDriftWarning("^2026.7.1", "2026.7.1"), true);
+  assert.equal(hasDriftWarning(">=2026.7.1", "not-semver"), true);
 });
 
 test("package contract classifier reports advertised npm pack blockers", () => {

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -984,6 +984,9 @@ test("package contract classifier compares minimum host semver with the build ve
   assert.equal(hasDriftWarning(">=2026.6.5", "2026.7.1-2"), false);
   assert.equal(hasDriftWarning(">=2026.7.1-1", "2026.7.1-2"), false);
   assert.equal(hasDriftWarning(">=2026.7.1-2+build.1", "2026.7.1-2+build.2"), false);
+  assert.equal(hasDriftWarning(">=9007199254740992.0.0", "9007199254740992.0.0"), false);
+  assert.equal(hasDriftWarning(">=9007199254740992.0.0", "9007199254740993.0.0"), false);
+  assert.equal(hasDriftWarning(">=9007199254740993.0.0", "9007199254740992.0.0"), true);
   assert.equal(hasDriftWarning(">=2026.7.1", "2026.7.1-2"), true);
   assert.equal(hasDriftWarning(">=2026.7.2", "2026.7.1"), true);
   assert.equal(hasDriftWarning("^2026.7.1", "2026.7.1"), true);


### PR DESCRIPTION
Closes openclaw/clawhub#3287

## What Problem This Solves

Fixes an issue where plugin authors validating a package would receive a `package-min-host-version-drift` warning when the plugin was built with a newer OpenClaw SDK but had been tested against an older compatible host floor.

## Why This Change Was Made

Compare the declared minimum host floor and build version using SemVer precedence instead of requiring exact string equality. Invalid metadata and minimum versions newer than the build target still report drift; build metadata is ignored for precedence, and no runtime dependency is added.

## User Impact

Plugin authors can preserve accurate build provenance while declaring a lower tested compatibility floor without receiving a misleading metadata warning.

## Evidence

- `node --test test/report.test.js` — 25/25 passed.
- `npm run check` — 216/216 tests passed and package contents passed (run from a temporary path without spaces because the repository's existing workspace-plan test misparses checkout paths containing spaces).
- `git diff --check` — passed.
- `CRABPOT_PLUGIN_INSPECTOR_CLI=source CRABPOT_PLUGIN_INSPECTOR_DIR=../plugin-inspector npm run plugin-inspector:smoke` — source-mode smoke completed and generated the corpus report.

Regression coverage includes equal, older, newer, prerelease, build-metadata, invalid-range, and invalid-build cases, including the exact `>=2026.6.5` / `2026.7.1-2` report from the issue.
