### PR TITLE
feat: add version-resolved OpenClaw compatibility checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Resolve `latest`, `beta`, or exact OpenClaw npm versions for compatibility inspection, reuse prepared targets from cache, and report exact target/source metadata.
+
 ### Fixed
 
+- Treat version-derived API removals inside a plugin's declared OpenClaw range as author-facing errors while keeping out-of-range targets informational, including beta eligibility against the upcoming stable version.
 - Accept tested minimum OpenClaw host versions below a plugin's build version without reporting package metadata drift.
 
 ## 0.3.19 - 2026-07-27

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ checkout. If an OpenClaw checkout is supplied with `--openclaw <path>`, the
 inspector only reads public compatibility surfaces such as compat records, SDK
 exports, hook names, manifest fields, and registrar metadata.
 
+Pass `--openclaw-version latest`, `--openclaw-version beta`, or an exact
+published version to resolve an official OpenClaw npm target. Reports keep the
+exact resolved version and npm source metadata. Prepared targets are cached, so
+batch and repeated inspections do not download the same OpenClaw package for
+each plugin.
+
 ## Quick Start
 
 Run this from a plugin package root:
@@ -181,6 +187,7 @@ Common options:
 | `--config <path>` | Read a standalone config file. Required for fixture-suite `report`. |
 | `--out <dir>` | Write reports somewhere other than `reports/`. |
 | `--openclaw <path>` | Compare against a local OpenClaw checkout. |
+| `--openclaw-version latest\|beta\|<exact>` | Resolve and compare against an official OpenClaw npm release. |
 | `--no-openclaw` | Disable OpenClaw checkout comparison. |
 | `--runtime` / `--capture` | Add opt-in runtime registration capture. |
 | `--no-runtime` / `--no-capture` | Disable runtime capture even when config enables it. |
@@ -298,7 +305,7 @@ Important report sections:
 | --- | --- |
 | `status` | `pass` unless hard breakages exist. |
 | `summary` | Counts for fixtures, breakages, warnings, suggestions, issues, issue classes, and contract probes. |
-| `targetOpenClaw` | Status and public compatibility data read from the optional OpenClaw checkout. |
+| `targetOpenClaw` | Exact resolved version, source metadata, cache state, and public compatibility data for the selected OpenClaw target. |
 | `fixtures` | Per-plugin metadata, hooks, registrations, manifest contracts, package data, SDK imports, and SDK deprecation evidence. |
 | `breakages` | Blocking compatibility failures. |
 | `warnings` / `suggestions` | Non-blocking compatibility findings. |
@@ -309,8 +316,9 @@ Important report sections:
 
 Default `check`, `ci`, and `batch` reports include both author-facing and
 internal findings. Pass `--author-facing` when producing plugin-author output;
-that filtered view includes only findings with `authorRemediation.summary` and
-`authorRemediation.docsUrl`.
+that filtered view includes only findings with `authorRemediation.summary`.
+Curated fixes include `authorRemediation.docsUrl`; dynamically discovered API
+removals use generic remediation without inventing a documentation URL.
 Current author-facing deprecation warnings include deprecated SDK helpers such
 as `loadSessionStore(...)` when a plugin still depends on the legacy whole-store
 session shape.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "@openclaw/plugin-inspector",
+  "version": "0.3.19",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/plugin-inspector",
+      "version": "0.3.19",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.8.5",
+        "tar": "^7.5.22"
+      },
+      "bin": {
+        "plugin-inspector": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "./execution-results": "./src/execution-results.js",
     "./import-loop-profile": "./src/import-loop-profile.js",
     "./openclaw-target": "./src/openclaw-target.js",
+    "./openclaw-version": "./src/openclaw-version.js",
     "./platform-probes": "./src/platform-probes.js",
     "./profile-diff": "./src/profile-diff.js",
     "./ref-diff": "./src/ref-diff.js",
@@ -69,5 +70,9 @@
     "plugin",
     "compatibility",
     "ci"
-  ]
+  ],
+  "dependencies": {
+    "semver": "^7.8.5",
+    "tar": "^7.5.22"
+  }
 }

--- a/src/advanced.js
+++ b/src/advanced.js
@@ -117,6 +117,13 @@ export {
   readOpenClawTargetSurface,
 } from "./openclaw-target.js";
 export {
+  openClawEligibilityVersion,
+  prepareOpenClawTarget,
+  resolveOpenClawTargetVersion,
+  satisfiesOpenClawCompatibilityRange,
+  satisfiesOpenClawVersionRange,
+} from "./openclaw-version.js";
+export {
   captureEntrypoint,
   captureEntrypointWithMockSdk,
   inspectCompatibilityFixtureSet,

--- a/src/api.js
+++ b/src/api.js
@@ -46,6 +46,7 @@ export async function inspectPluginRoot(options = {}) {
     authorFacing: options.authorFacing,
     generatedAt: options.generatedAt,
     openclawPath: options.openclawPath,
+    openclawVersion: options.openclawVersion,
     executionResults: options.executionResults,
     targetOpenClaw: options.targetOpenClaw,
   });
@@ -62,6 +63,7 @@ export async function inspectCompatibilityFixtureSetConfig(options = {}) {
     authorFacing: options.authorFacing,
     generatedAt: options.generatedAt,
     openclawPath: options.openclawPath,
+    openclawVersion: options.openclawVersion,
     executionResults: options.executionResults,
     targetOpenClaw: options.targetOpenClaw,
   });
@@ -117,6 +119,7 @@ export async function buildFixtureSetColdImportReadiness(options = {}) {
       authorFacing: options.authorFacing,
       generatedAt: options.generatedAt,
       openclawPath: options.openclawPath,
+      openclawVersion: options.openclawVersion,
       executionResults: options.executionResults,
       targetOpenClaw: options.targetOpenClaw,
     }));
@@ -150,6 +153,7 @@ export async function buildFixtureSetWorkspacePlan(options = {}) {
       authorFacing: options.authorFacing,
       generatedAt: options.generatedAt,
       openclawPath: options.openclawPath,
+      openclawVersion: options.openclawVersion,
       executionResults: options.executionResults,
       targetOpenClaw: options.targetOpenClaw,
     }));

--- a/src/batch.js
+++ b/src/batch.js
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { renderMarkdownTable, writeJsonMarkdownArtifacts } from "./artifacts.js";
 import { runPluginCheck } from "./api.js";
+import { prepareOpenClawTarget, resolveOpenClawTargetVersion } from "./openclaw-version.js";
 
 const ignoredDirs = new Set([
   ".git",
@@ -22,6 +23,11 @@ export async function runBatchAnalysis(options = {}) {
   const outRoot = path.resolve(rootDir, outDir);
   const concurrency = Math.max(1, Math.min(Math.round(options.concurrency ?? 4), 32));
   const keepPluginReports = options.keepPluginReports === true;
+  const targetOpenClaw =
+    options.targetOpenClaw ??
+    (options.openclawVersion
+      ? await prepareOpenClawTarget(await resolveOpenClawTargetVersion(options.openclawVersion, options), options)
+      : undefined);
   const pluginRoots = await discoverPluginRoots(rootDir);
   const tempRoot = keepPluginReports ? null : await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-batch-"));
   const entries = [];
@@ -37,6 +43,7 @@ export async function runBatchAnalysis(options = {}) {
           rootDir,
           outDir: reportsRoot,
           openclawPath: options.openclawPath,
+          targetOpenClaw,
         }),
       );
     });
@@ -113,6 +120,7 @@ async function inspectBatchPlugin(pluginRoot, options) {
       configPath: options.configPath,
       mockSdk: options.mockSdk,
       openclawPath: options.openclawPath,
+      targetOpenClaw: options.targetOpenClaw,
       outDir: options.outDir,
       pluginRoot,
     });

--- a/src/cli.js
+++ b/src/cli.js
@@ -57,9 +57,10 @@ try {
 }
 
 async function runBatch(commandArgs) {
-  const inputDir = readFirstPositional(commandArgs, new Set(["--out", "--openclaw", "--concurrency"]));
+  const inputDir = readFirstPositional(commandArgs, new Set(["--out", "--openclaw", "--openclaw-version", "--concurrency"]));
   const outDir = readFlag(commandArgs, "--out") ?? "reports";
   const openclawPath = commandArgs.includes("--no-openclaw") ? false : readFlag(commandArgs, "--openclaw");
+  const openclawVersion = readOpenClawVersion(commandArgs);
   const concurrency = Number(readFlag(commandArgs, "--concurrency") ?? "4");
   const json = commandArgs.includes("--json");
   const check = commandArgs.includes("--check");
@@ -72,6 +73,7 @@ async function runBatch(commandArgs) {
     rootDir: inputDir,
     outDir,
     openclawPath,
+    openclawVersion,
     concurrency,
     authorFacing,
     keepPluginReports,
@@ -105,6 +107,7 @@ async function runCheck(commandArgs, options = {}) {
   const pluginRoot = readFlag(commandArgs, "--plugin-root") ?? readFlag(commandArgs, "--root");
   const outDir = readFlag(commandArgs, "--out") ?? "reports";
   const openclawPath = commandArgs.includes("--no-openclaw") ? false : readFlag(commandArgs, "--openclaw");
+  const openclawVersion = readOpenClawVersion(commandArgs);
   const json = commandArgs.includes("--json");
   const capture = readRuntimeFlag(commandArgs);
   const mockSdk = readMockSdkFlag(commandArgs);
@@ -118,6 +121,7 @@ async function runCheck(commandArgs, options = {}) {
     configPath,
     mockSdk,
     openclawPath,
+    openclawVersion,
     outDir,
     pluginRoot,
   });
@@ -169,15 +173,17 @@ async function runReport(command, commandArgs) {
   const configPath = readFlag(commandArgs, "--config");
   const outDir = readFlag(commandArgs, "--out") ?? "reports";
   const openclawPath = commandArgs.includes("--no-openclaw") ? false : readFlag(commandArgs, "--openclaw");
+  const openclawVersion = readOpenClawVersion(commandArgs);
   const check = commandArgs.includes("--check") || command === "ci";
   const json = commandArgs.includes("--json");
   const ciOutputs = readCiOutputFlags(commandArgs);
   const authorFacing = readAuthorFacingFlag(commandArgs);
   const config = await loadInspectorConfig(configPath);
-  const report = authorFacing
-    ? await inspectCompatibilityFixtureSet(config, { authorFacing, openclawPath })
+  const compatibilityInspection = authorFacing || typeof openclawPath === "string" || openclawVersion !== null;
+  const report = compatibilityInspection
+    ? await inspectCompatibilityFixtureSet(config, { authorFacing, openclawPath, openclawVersion })
     : await inspectFixtureSet(config);
-  const paths = authorFacing
+  const paths = compatibilityInspection
     ? await writeCompatibilityReport(report, { cwd: config.rootDir, outDir })
     : await writeReport(report, { outDir });
   await writeCiOutputArtifacts(report, {
@@ -202,6 +208,7 @@ async function runCi(commandArgs) {
   const pluginRoot = readFlag(commandArgs, "--plugin-root") ?? readFlag(commandArgs, "--root");
   const outDir = readFlag(commandArgs, "--out") ?? "reports";
   const openclawPath = commandArgs.includes("--no-openclaw") ? false : readFlag(commandArgs, "--openclaw");
+  const openclawVersion = readOpenClawVersion(commandArgs);
   const json = commandArgs.includes("--json");
   const capture = readRuntimeFlag(commandArgs);
   const mockSdk = readMockSdkFlag(commandArgs);
@@ -215,6 +222,7 @@ async function runCi(commandArgs) {
     configPath,
     mockSdk,
     openclawPath,
+    openclawVersion,
     outDir,
     pluginRoot,
   });
@@ -256,12 +264,13 @@ async function runCiCompatibilityReport({
   configPath,
   mockSdk,
   openclawPath,
+  openclawVersion,
   outDir,
   pluginRoot,
 }) {
   if (configPath) {
     const config = await loadInspectorConfig(configPath, { cwd: pluginRoot });
-    const report = await inspectCompatibilityFixtureSet(config, { authorFacing, openclawPath });
+    const report = await inspectCompatibilityFixtureSet(config, { authorFacing, openclawPath, openclawVersion });
     await writeCompatibilityReport(report, { cwd: config.rootDir, outDir });
     return {
       report,
@@ -275,6 +284,7 @@ async function runCiCompatibilityReport({
     capture,
     mockSdk,
     openclawPath,
+    openclawVersion,
     outDir,
     pluginRoot,
   });
@@ -312,6 +322,19 @@ function readFlag(commandArgs, name) {
     return null;
   }
   return commandArgs[index + 1] ?? null;
+}
+
+function readOpenClawVersion(commandArgs) {
+  const index = commandArgs.indexOf("--openclaw-version");
+  if (index === -1) return null;
+  const version = commandArgs[index + 1];
+  if (!version || version.startsWith("-")) {
+    throw new Error("--openclaw-version requires a value");
+  }
+  if (version && (commandArgs.includes("--no-openclaw") || commandArgs.includes("--openclaw"))) {
+    throw new Error("--openclaw-version cannot be combined with --openclaw or --no-openclaw");
+  }
+  return version;
 }
 
 function findCaptureEntrypoint(commandArgs) {
@@ -452,13 +475,13 @@ function printHelp() {
 
 Usage:
   plugin-inspector
-  plugin-inspector check [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path>] [--no-openclaw] [--runtime] [--mock-sdk|--real-sdk] [--allow-execute] [--author-facing] [--json]
+  plugin-inspector check [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path> | --openclaw-version latest|beta|<exact> | --no-openclaw] [--runtime] [--mock-sdk|--real-sdk] [--allow-execute] [--author-facing] [--json]
   plugin-inspector config [--plugin-root <path>] [--config <path>] [--json]
   plugin-inspector init [--plugin-root <path>] [--config <path>] [--ci] [--scripts] [--package-manager npm|pnpm|yarn|bun] [--dry-run] [--json] [--force]
-  plugin-inspector report --config <path> [--out <dir>] [--openclaw <path>] [--no-openclaw] [--author-facing] [--check] [--json]
-  plugin-inspector batch <folder> [--out <dir>] [--openclaw <path>] [--no-openclaw] [--concurrency <n>] [--keep-plugin-reports] [--author-facing] [--check] [--json]
-  plugin-inspector inspect [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path>] [--no-openclaw] [--author-facing] [--check] [--json] [--sarif [path]] [--junit [path]] [--allow-execute]
-  plugin-inspector ci [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path>] [--no-openclaw] [--runtime] [--mock-sdk|--real-sdk] [--allow-execute] [--author-facing] [--json] [--no-sarif] [--no-junit]
+  plugin-inspector report --config <path> [--out <dir>] [--openclaw <path> | --openclaw-version latest|beta|<exact> | --no-openclaw] [--author-facing] [--check] [--json]
+  plugin-inspector batch <folder> [--out <dir>] [--openclaw <path> | --openclaw-version latest|beta|<exact> | --no-openclaw] [--concurrency <n>] [--keep-plugin-reports] [--author-facing] [--check] [--json]
+  plugin-inspector inspect [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path> | --openclaw-version latest|beta|<exact> | --no-openclaw] [--author-facing] [--check] [--json] [--sarif [path]] [--junit [path]] [--allow-execute]
+  plugin-inspector ci [--plugin-root <path>] [--config <path>] [--out <dir>] [--openclaw <path> | --openclaw-version latest|beta|<exact> | --no-openclaw] [--runtime] [--mock-sdk|--real-sdk] [--allow-execute] [--author-facing] [--json] [--no-sarif] [--no-junit]
   plugin-inspector capture <entrypoint> [--mock-sdk|--real-sdk] [--allow-execute] [--plugin-root <path>] [--output <path>]
 
 Default check runs from the current plugin root and writes reports/ unless --out is set.

--- a/src/compatibility-report.js
+++ b/src/compatibility-report.js
@@ -351,6 +351,12 @@ function targetOpenClawTable(targetOpenClaw = {}) {
     [
       ["Configured path", targetOpenClaw.configuredPath ?? "-"],
       ["Status", targetOpenClaw.status],
+      ["Requested version", targetOpenClaw.requestedVersion ?? "-"],
+      ["Resolved version", targetOpenClaw.version ?? "-"],
+      ["Range eligibility version", targetOpenClaw.eligibilityVersion ?? "-"],
+      ["Source", targetOpenClaw.source ? `${targetOpenClaw.source.type}:${targetOpenClaw.source.package}` : "-"],
+      ["NPM dist-tag", targetOpenClaw.source?.distTag ?? "-"],
+      ["Prepared cache", targetOpenClaw.cache ? (targetOpenClaw.cache.hit ? "hit" : "miss") : "-"],
       ["Compat registry", targetOpenClaw.compatRegistryPath ?? "-"],
       ["Compat records", targetOpenClaw.compatRecordCount ?? 0],
       ["Compat status counts", Object.entries(statusCounts).map(([status, count]) => `${status}:${count}`).join(", ") || "-"],

--- a/src/fixture-summary.js
+++ b/src/fixture-summary.js
@@ -3,6 +3,7 @@ import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { compatRecordForIssueCode } from "./contract-probes.js";
 import { readJsonFile } from "./json-file.js";
+import { satisfiesOpenClawCompatibilityRange } from "./openclaw-version.js";
 
 const conversationAccessHooks = new Set(["agent_end", "llm_input", "llm_output"]);
 const captureGapRegistrations = new Set([
@@ -464,30 +465,36 @@ export function classifyPackageContracts({ fixture, inspection, fixtureReport })
 }
 
 export function classifyTargetOpenClawCoverage({ fixture, inspection, fixtureReport, targetOpenClaw }) {
+  const breakages = [];
   const warnings = [];
+  const suggestions = [];
   const logs = [];
   const decisions = [];
+  const findingContext = { breakages, warnings, suggestions, fixtureReport, targetOpenClaw };
 
-  classifyHookNameCoverage({ fixture, inspection, targetOpenClaw, warnings, logs });
-  classifyRegistrationNameCoverage({ fixture, inspection, targetOpenClaw, warnings, logs });
-  classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, warnings, logs, decisions });
+  classifyHookNameCoverage({ fixture, inspection, targetOpenClaw, logs, findingContext });
+  classifyRegistrationNameCoverage({ fixture, inspection, targetOpenClaw, logs, findingContext });
+  classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, warnings, logs, decisions, findingContext });
   classifyManifestFieldCoverage({ fixture, fixtureReport, targetOpenClaw, warnings, logs, decisions });
 
-  return { warnings, logs, decisions };
+  return { breakages, warnings, suggestions, logs, decisions };
 }
 
 export function classifyCompatibilityFixture({ fixture, inspection, fixtureReport, targetOpenClaw }) {
+  const breakages = [];
   const warnings = [];
   const suggestions = [];
   const logs = [];
   const decisions = [];
 
   if (inspection.status !== "ok") {
-    return { warnings, suggestions, logs, decisions };
+    return { breakages, warnings, suggestions, logs, decisions };
   }
 
   const targetCoverage = classifyTargetOpenClawCoverage({ fixture, inspection, fixtureReport, targetOpenClaw });
+  breakages.push(...targetCoverage.breakages);
   warnings.push(...targetCoverage.warnings);
+  suggestions.push(...targetCoverage.suggestions);
   logs.push(...targetCoverage.logs);
   decisions.push(...targetCoverage.decisions);
 
@@ -701,7 +708,7 @@ export function classifyCompatibilityFixture({ fixture, inspection, fixtureRepor
     });
   }
 
-  return { warnings, suggestions, logs, decisions };
+  return { breakages, warnings, suggestions, logs, decisions };
 }
 
 function classifySdkDeprecations({ fixture, inspection, fixtureReport, warnings, decisions }) {
@@ -807,7 +814,7 @@ function registrationCaptureGapDetails(inspection, targetOpenClaw) {
   return apiRegistrationDetails.filter((registration) => captureGapRegistrations.has(registration.name));
 }
 
-function classifyHookNameCoverage({ fixture, inspection, targetOpenClaw, warnings, logs }) {
+function classifyHookNameCoverage({ fixture, inspection, targetOpenClaw, logs, findingContext }) {
   if (targetOpenClaw.status !== "ok" || targetOpenClaw.hookNames.length === 0) {
     return;
   }
@@ -825,16 +832,18 @@ function classifyHookNameCoverage({ fixture, inspection, targetOpenClaw, warning
     return;
   }
 
-  warnings.push({
+  addVersionDerivedFinding({
+    ...findingContext,
+    finding: {
     fixture: fixture.id,
     code: "unknown-hook-name",
-    level: "warning",
     message: "fixture registers hooks that are not present in the target OpenClaw hook registry",
     evidence: detailEvidence(unknownHooks),
+    },
   });
 }
 
-function classifyRegistrationNameCoverage({ fixture, inspection, targetOpenClaw, warnings, logs }) {
+function classifyRegistrationNameCoverage({ fixture, inspection, targetOpenClaw, logs, findingContext }) {
   if (targetOpenClaw.status !== "ok" || targetOpenClaw.apiRegistrars.length === 0) {
     return;
   }
@@ -855,16 +864,18 @@ function classifyRegistrationNameCoverage({ fixture, inspection, targetOpenClaw,
     return;
   }
 
-  warnings.push({
+  addVersionDerivedFinding({
+    ...findingContext,
+    finding: {
     fixture: fixture.id,
     code: "unknown-registration-name",
-    level: "warning",
     message: "fixture calls api.register* methods that are not present in the target OpenClaw plugin API builder",
     evidence: detailEvidence(unknownRegistrations),
+    },
   });
 }
 
-function classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, warnings, logs, decisions }) {
+function classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, warnings, logs, decisions, findingContext }) {
   if (targetOpenClaw.status !== "ok" || targetOpenClaw.sdkExports.length === 0 || fixtureReport.sdkImports.length === 0) {
     return;
   }
@@ -888,13 +899,15 @@ function classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, war
   }
 
   if (unknownImports.length > 0) {
-    warnings.push({
+    addVersionDerivedFinding({
+      ...findingContext,
+      finding: {
       fixture: fixture.id,
       code: "sdk-export-missing",
-      level: "warning",
       message: "fixture imports plugin SDK aliases that are not exported by the target OpenClaw package",
       evidence: detailEvidence(unknownImports, "specifier"),
       compatRecord: "plugin-sdk-export-aliases",
+      },
     });
     decisions.push({
       fixture: fixture.id,
@@ -921,6 +934,52 @@ function classifySdkImportCoverage({ fixture, fixtureReport, targetOpenClaw, war
       evidence: unique(reservedImports.map((sdkImport) => sdkImport.specifier)).join(", "),
     });
   }
+}
+
+function addVersionDerivedFinding({ finding, fixtureReport, targetOpenClaw, breakages, warnings, suggestions }) {
+  const compatibility = targetCompatibility(fixtureReport, targetOpenClaw);
+  if (!compatibility) {
+    warnings.push({ ...finding, level: "warning" });
+    return;
+  }
+
+  if (compatibility.inDeclaredRange) {
+    breakages.push({
+      ...finding,
+      level: "breakage",
+      compatibility,
+      authorRemediation: {
+        summary:
+          "Update the plugin to use APIs available in the target OpenClaw version, or narrow its declared compatibility range.",
+      },
+      authorRemediationDocs: false,
+    });
+    return;
+  }
+
+  suggestions.push({
+    ...finding,
+    level: "information",
+    message: `${finding.message}; the resolved target is outside the plugin's declared compatibility range`,
+    compatibility,
+  });
+}
+
+function targetCompatibility(fixtureReport, targetOpenClaw) {
+  const declaredRange = fixtureReport.package?.openclaw?.compatPluginApi;
+  const targetVersion = targetOpenClaw.version;
+  const evaluatedVersion = targetOpenClaw.eligibilityVersion ?? targetOpenClaw.version;
+  if (!declaredRange || !targetVersion || !evaluatedVersion || !targetOpenClaw.requestedVersion) return null;
+  return {
+    declaredRange,
+    targetVersion,
+    evaluatedVersion,
+    inDeclaredRange: satisfiesOpenClawCompatibilityRange({
+      targetVersion,
+      eligibilityVersion: evaluatedVersion,
+      range: declaredRange,
+    }),
+  };
 }
 
 function classifyManifestFieldCoverage({ fixture, fixtureReport, targetOpenClaw, warnings, logs, decisions }) {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ import * as executionResultsApi from "./execution-results.js";
 import * as importLoopProfileApi from "./import-loop-profile.js";
 import * as inspectorApi from "./inspector.js";
 import * as issuesApi from "./issues.js";
-import * as openClawTargetApi from "./openclaw-target.js";
+import * as openClawTargetApi from "./openclaw-version.js";
+import * as openClawTargetSurfaceApi from "./openclaw-target.js";
 import * as profileDiffApi from "./profile-diff.js";
 import * as refDiffApi from "./ref-diff.js";
 import * as reportApi from "./report.js";
@@ -67,8 +68,16 @@ export const reports = Object.freeze({
   issueId: issuesApi.issueId,
   classifyIssueFinding: issuesApi.classifyIssueFinding,
   knownIssueCodes: issuesApi.knownIssueCodes,
-  openClawTargetPathCandidates: openClawTargetApi.openClawTargetPathCandidates,
-  readOpenClawTargetSurface: openClawTargetApi.readOpenClawTargetSurface,
+  openClawTargetPathCandidates: openClawTargetSurfaceApi.openClawTargetPathCandidates,
+  readOpenClawTargetSurface: openClawTargetSurfaceApi.readOpenClawTargetSurface,
+});
+
+export const openClawTargets = Object.freeze({
+  resolveVersion: openClawTargetApi.resolveOpenClawTargetVersion,
+  prepare: openClawTargetApi.prepareOpenClawTarget,
+  eligibilityVersion: openClawTargetApi.openClawEligibilityVersion,
+  satisfiesCompatibilityRange: openClawTargetApi.satisfiesOpenClawCompatibilityRange,
+  satisfiesRange: openClawTargetApi.satisfiesOpenClawVersionRange,
 });
 
 export const contracts = Object.freeze({

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -9,6 +9,7 @@ import { captureApiOptionsForPlugin } from "./capture-config.js";
 import { fixtureCheckoutPath, fixtureSourceRoot } from "./config.js";
 import { buildCompatibilityFixtureReport } from "./fixture-summary.js";
 import { readOpenClawTargetSurface } from "./openclaw-target.js";
+import { prepareOpenClawTarget, resolveOpenClawTargetVersion } from "./openclaw-version.js";
 import { buildCompatibilityReport, buildReport } from "./report.js";
 import { inspectSdkDeprecations } from "./sdk-deprecation-rules.js";
 
@@ -26,11 +27,13 @@ export async function inspectCompatibilityFixtureSet(config, options = {}) {
   const { inspections, failures } = await inspectConfiguredFixtures(config, options);
   const targetOpenClaw =
     options.targetOpenClaw ??
-    (await readOpenClawTargetSurface({
-      configuredPath: options.openclawPath,
-      manifest: config,
-      rootDir: config.rootDir,
-    }));
+    (options.openclawVersion
+      ? await prepareOpenClawTarget(await resolveOpenClawTargetVersion(options.openclawVersion, options), options)
+      : await readOpenClawTargetSurface({
+          configuredPath: options.openclawPath,
+          manifest: config,
+          rootDir: config.rootDir,
+        }));
 
   return buildCompatibilityReport({
     config,

--- a/src/issues.js
+++ b/src/issues.js
@@ -518,7 +518,10 @@ export function buildIssues({ breakages = [], warnings = [], suggestions = [], t
       runtimeCoverage: finding.runtimeCoverage ?? null,
       ...(finding.authorRemediation
         ? {
-            authorRemediation: withAuthorRemediationDocs(finding.code, finding.authorRemediation),
+            authorRemediation:
+              finding.authorRemediationDocs === false
+                ? finding.authorRemediation
+                : withAuthorRemediationDocs(finding.code, finding.authorRemediation),
           }
         : {}),
     }));

--- a/src/openclaw-target.js
+++ b/src/openclaw-target.js
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 
 export const defaultOpenClawCheckoutPaths = ["./openclaw", "../openclaw"];
@@ -24,6 +24,10 @@ export async function readOpenClawTargetSurface(options = {}) {
       searchedPaths: requestedPaths,
       status: "missing",
     });
+  }
+
+  if (match.kind === "package") {
+    return readPackedOpenClawTargetSurface({ rootDir, requestedPaths, ...match });
   }
 
   const { requestedPath, resolvedPath, registryPath } = match;
@@ -251,10 +255,189 @@ function findTargetCheckout(rootDir, requestedPaths) {
     const resolvedPath = path.resolve(rootDir, requestedPath);
     const registryPath = path.join(resolvedPath, "src/plugins/compat/registry.ts");
     if (existsSync(registryPath)) {
-      return { requestedPath, resolvedPath, registryPath };
+      return { kind: "checkout", requestedPath, resolvedPath, registryPath };
+    }
+    if (existsSync(path.join(resolvedPath, "package.json")) && existsSync(path.join(resolvedPath, "dist"))) {
+      return { kind: "package", requestedPath, resolvedPath };
     }
   }
   return null;
+}
+
+async function readPackedOpenClawTargetSurface({ rootDir, requestedPaths, requestedPath, resolvedPath }) {
+  const packagePath = path.join(resolvedPath, "package.json");
+  const packageJson = JSON.parse(await readFile(packagePath, "utf8"));
+  if (packageJson.name !== "openclaw") {
+    return emptyTargetSurface({ configuredPath: requestedPath, searchedPaths: requestedPaths, status: "missing" });
+  }
+
+  const distPath = path.join(resolvedPath, "dist");
+  const declarationFiles = await listDeclarationFiles(distPath);
+  const declarations = [];
+  for (const filePath of declarationFiles) {
+    declarations.push({ filePath, source: await readFile(filePath, "utf8") });
+  }
+  const apiDeclaration = declarations
+    .map((declaration) => ({
+      ...declaration,
+      values: parseObjectTypeFields(declaration.source, "OpenClawPluginApi", (value) => value.startsWith("register")),
+    }))
+    .sort((left, right) => right.values.length - left.values.length)[0];
+  const hookDeclaration = declarations.find((declaration) => declaration.source.includes("type PluginHookName ="));
+  const manifestDeclaration = declarations.find((declaration) => declaration.source.includes("type PluginManifestRecord ="));
+  const manifestContractDeclaration = declarations.find((declaration) => declaration.source.includes("type PluginManifestContracts ="));
+  const apiRegistrars = apiDeclaration?.values ?? [];
+  const hookNames = hookDeclaration ? parseStringUnion(hookDeclaration.source, "PluginHookName") : [];
+  const manifestFields = manifestDeclaration
+    ? parseObjectTypeFields(manifestDeclaration.source, "PluginManifestRecord")
+    : [];
+  const manifestContractFields = manifestContractDeclaration
+    ? parseObjectTypeFields(manifestContractDeclaration.source, "PluginManifestContracts")
+    : [];
+  const sdkExports = parsePluginSdkExports(packageJson);
+
+  return {
+    configuredPath: requestedPath,
+    searchedPaths: requestedPaths,
+    status: "ok",
+    version: packageJson.version ?? null,
+    compatRegistryPath: null,
+    compatRecordCount: 0,
+    compatRecords: [],
+    compatRecordStatuses: {},
+    hookTypesPath: hookDeclaration ? relativePath(rootDir, hookDeclaration.filePath) : null,
+    hookNameCount: hookNames.length,
+    hookNames,
+    apiBuilderPath: apiDeclaration ? relativePath(rootDir, apiDeclaration.filePath) : null,
+    apiRegistrarCount: apiRegistrars.length,
+    apiRegistrars,
+    capturedRegistrationPath: apiDeclaration ? relativePath(rootDir, apiDeclaration.filePath) : null,
+    capturedRegistrarCount: apiRegistrars.length,
+    capturedRegistrars: apiRegistrars,
+    packagePath: relativePath(rootDir, packagePath),
+    sdkExportCount: sdkExports.length,
+    sdkExports,
+    pluginSdkEntrypointsPath: null,
+    reservedSdkExportCount: 0,
+    reservedSdkExports: [],
+    supportedFacadeSdkExports: [],
+    publicPluginOwnedSdkExports: [],
+    manifestTypesPath: manifestDeclaration ? relativePath(rootDir, manifestDeclaration.filePath) : null,
+    manifestFieldCount: manifestFields.length,
+    manifestFields,
+    manifestContractFieldCount: manifestContractFields.length,
+    manifestContractFields,
+  };
+}
+
+async function listDeclarationFiles(rootDir) {
+  const files = [];
+  const entries = await readdir(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listDeclarationFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".d.ts")) {
+      files.push(entryPath);
+    }
+  }
+  return files.sort();
+}
+
+function parseObjectTypeFields(source, typeName, filter = () => true) {
+  const body = readObjectTypeBody(source, typeName);
+  if (!body) return [];
+  return unique(parseTopLevelTypeProperties(body).filter(filter)).sort();
+}
+
+function parseTopLevelTypeProperties(body) {
+  const properties = [];
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let propertyStart = true;
+
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    const next = body[index + 1];
+    if (char === "/" && next === "*") {
+      index = body.indexOf("*/", index + 2);
+      if (index === -1) break;
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      const newline = body.indexOf("\n", index + 2);
+      if (newline === -1) break;
+      index = newline;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      index = skipQuotedTypeText(body, index);
+      continue;
+    }
+    if (char === "{") braceDepth += 1;
+    else if (char === "}") braceDepth -= 1;
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth -= 1;
+    else if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth -= 1;
+
+    if (braceDepth !== 0 || bracketDepth !== 0 || parenDepth !== 0) continue;
+    if (char === ";" || char === ",") {
+      propertyStart = true;
+      continue;
+    }
+    if (/\s/.test(char)) continue;
+    if (!propertyStart || !/[A-Za-z_$]/.test(char)) {
+      propertyStart = false;
+      continue;
+    }
+
+    const match = body.slice(index).match(/^([A-Za-z_$][A-Za-z0-9_$]*)/);
+    if (!match) {
+      propertyStart = false;
+      continue;
+    }
+    const name = match[1];
+    index += name.length - 1;
+    if (name === "readonly") continue;
+    let cursor = index + 1;
+    while (/\s/.test(body[cursor] ?? "")) cursor += 1;
+    if (body[cursor] === "?") cursor += 1;
+    while (/\s/.test(body[cursor] ?? "")) cursor += 1;
+    if (body[cursor] === ":") properties.push(name);
+    propertyStart = false;
+  }
+  return properties;
+}
+
+function skipQuotedTypeText(source, quoteIndex) {
+  const quote = source[quoteIndex];
+  for (let index = quoteIndex + 1; index < source.length; index += 1) {
+    if (source[index] === "\\") index += 1;
+    else if (source[index] === quote) return index;
+  }
+  return source.length - 1;
+}
+
+function readObjectTypeBody(source, typeName) {
+  const marker = new RegExp(`(?:export\\s+)?type\\s+${typeName}(?:\\$\\d+)?\\s*=\\s*\\{`, "g");
+  const match = marker.exec(source);
+  if (!match) return null;
+  const start = match.index + match[0].length;
+  let depth = 1;
+  for (let index = start; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(start, index);
+  }
+  return null;
+}
+
+function parseStringUnion(source, typeName) {
+  const match = source.match(new RegExp(`type\\s+${typeName}\\s*=\\s*([^;]+);`));
+  return match ? unique([...match[1].matchAll(/["']([^"']+)["']/g)].map((item) => item[1])).sort() : [];
 }
 
 function emptyTargetSurface({ configuredPath, searchedPaths = undefined, status }) {

--- a/src/openclaw-version.js
+++ b/src/openclaw-version.js
@@ -106,7 +106,8 @@ export async function prepareOpenClawTarget(resolvedTarget, options = {}) {
 }
 
 export function openClawEligibilityVersion(version) {
-  return version.replace(/-(?:beta\.[0-9A-Za-z.-]+|\d+)$/, "");
+  const parsed = semver.parse(version);
+  return parsed ? `${parsed.major}.${parsed.minor}.${parsed.patch}` : version;
 }
 
 export function satisfiesOpenClawVersionRange(version, range) {
@@ -216,7 +217,10 @@ function isExactOpenClawVersion(value) {
 }
 
 function normalizeRegistryUrl(value) {
-  return String(value).replace(/\/+$/, "");
+  const url = String(value);
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 47) end -= 1;
+  return url.slice(0, end);
 }
 
 function sanitizeUrlForReport(value) {

--- a/src/openclaw-version.js
+++ b/src/openclaw-version.js
@@ -115,13 +115,19 @@ export function satisfiesOpenClawVersionRange(version, range) {
 
 export function satisfiesOpenClawCompatibilityRange({ targetVersion, eligibilityVersion, range }) {
   try {
+    const target = semver.parse(targetVersion);
+    if (!target) return false;
     return new semver.Range(range).set.some((comparators) => {
       const branch = comparators.map((comparator) => comparator.value).filter(Boolean).join(" ") || "*";
       if (semver.satisfies(targetVersion, branch)) return true;
-      const includesPrerelease = comparators.some(
-        (comparator) => (comparator.semver?.prerelease?.length ?? 0) > 0,
+      const constrainsTargetPrerelease = comparators.some(
+        (comparator) =>
+          (comparator.semver?.prerelease?.length ?? 0) > 0 &&
+          comparator.semver.major === target.major &&
+          comparator.semver.minor === target.minor &&
+          comparator.semver.patch === target.patch,
       );
-      return !includesPrerelease && semver.satisfies(eligibilityVersion, branch);
+      return !constrainsTargetPrerelease && semver.satisfies(eligibilityVersion, branch);
     });
   } catch {
     return false;

--- a/src/openclaw-version.js
+++ b/src/openclaw-version.js
@@ -1,0 +1,236 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import semver from "semver";
+import { x as extractTar } from "tar";
+import { readOpenClawTargetSurface } from "./openclaw-target.js";
+
+const defaultRegistryUrl = "https://registry.npmjs.org";
+const supportedTags = new Set(["latest", "beta"]);
+const downloadUrls = new WeakMap();
+
+export async function resolveOpenClawTargetVersion(requestedVersion, options = {}) {
+  const requested = requestedVersion ?? "latest";
+  if (typeof requested !== "string" || requested.trim().length === 0) {
+    throw new Error("OpenClaw target version must be latest, beta, or an exact version");
+  }
+
+  const registryUrl = normalizeRegistryUrl(
+    options.registryUrl ?? process.env.PLUGIN_INSPECTOR_NPM_REGISTRY ?? defaultRegistryUrl,
+  );
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  let version = requested;
+  let distTag = null;
+
+  if (supportedTags.has(requested)) {
+    const metadata = await fetchJson(`${registryUrl}/openclaw`, fetchImpl);
+    version = metadata["dist-tags"]?.[requested];
+    if (typeof version !== "string" || version.length === 0) {
+      throw new Error(`OpenClaw npm dist-tag ${requested} did not resolve to an exact version`);
+    }
+    if (!isExactOpenClawVersion(version)) {
+      throw new Error(`OpenClaw npm dist-tag ${requested} did not resolve to a valid exact version`);
+    }
+    distTag = requested;
+  } else if (!isExactOpenClawVersion(requested)) {
+    throw new Error("--openclaw-version must be latest, beta, or an exact OpenClaw version");
+  }
+
+  const versionMetadata = await fetchJson(`${registryUrl}/openclaw/${encodeURIComponent(version)}`, fetchImpl);
+  if (versionMetadata.version !== version || typeof versionMetadata.dist?.tarball !== "string") {
+    throw new Error(`OpenClaw npm metadata for ${version} is incomplete`);
+  }
+  if (!hasVerifiableIntegrity(versionMetadata.dist)) {
+    throw new Error(`OpenClaw npm metadata for ${version} has no verifiable integrity metadata`);
+  }
+
+  const resolvedTarget = {
+    requestedVersion: requested,
+    version,
+    eligibilityVersion: openClawEligibilityVersion(version),
+    source: {
+      type: "npm",
+      package: "openclaw",
+      registry: sanitizeUrlForReport(registryUrl),
+      distTag,
+      tarball: sanitizeUrlForReport(versionMetadata.dist.tarball),
+      integrity: versionMetadata.dist.integrity ?? null,
+      shasum: versionMetadata.dist.shasum ?? null,
+      repository: sanitizeRepositoryForReport(versionMetadata.repository),
+    },
+  };
+  downloadUrls.set(resolvedTarget, versionMetadata.dist.tarball);
+  return resolvedTarget;
+}
+
+export async function prepareOpenClawTarget(resolvedTarget, options = {}) {
+  if (!resolvedTarget?.version || !resolvedTarget?.source?.integrity && !resolvedTarget?.source?.shasum) {
+    throw new Error("prepareOpenClawTarget requires a resolved npm target");
+  }
+  if (!downloadUrls.has(resolvedTarget)) {
+    throw new Error("prepareOpenClawTarget requires the target object directly returned by resolveOpenClawTargetVersion");
+  }
+
+  const cacheDir = path.resolve(
+    options.cacheDir ??
+      process.env.PLUGIN_INSPECTOR_CACHE_DIR ??
+      path.join(process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), ".cache"), "plugin-inspector"),
+  );
+  const cacheKey = cacheKeyFor(resolvedTarget);
+  const targetDir = path.join(cacheDir, "openclaw", cacheKey);
+  const packageDir = path.join(targetDir, "package");
+  let cacheHit = await isPreparedPackage(packageDir, resolvedTarget.version);
+
+  if (!cacheHit) {
+    await preparePackageArchive(resolvedTarget, { ...options, cacheDir, targetDir });
+    cacheHit = false;
+  }
+
+  const surface = await readOpenClawTargetSurface({ rootDir: packageDir, configuredPath: "." });
+  if (surface.status !== "ok") {
+    throw new Error(`prepared OpenClaw ${resolvedTarget.version} package has no readable public plugin surface`);
+  }
+
+  return {
+    ...surface,
+    configuredPath: `npm:openclaw@${resolvedTarget.version}`,
+    searchedPaths: [`npm:openclaw@${resolvedTarget.version}`],
+    requestedVersion: resolvedTarget.requestedVersion,
+    version: resolvedTarget.version,
+    eligibilityVersion: resolvedTarget.eligibilityVersion,
+    source: resolvedTarget.source,
+    cache: { hit: cacheHit, key: cacheKey },
+  };
+}
+
+export function openClawEligibilityVersion(version) {
+  return version.replace(/-(?:beta\.[0-9A-Za-z.-]+|\d+)$/, "");
+}
+
+export function satisfiesOpenClawVersionRange(version, range) {
+  return Boolean(semver.valid(version) && semver.validRange(range) && semver.satisfies(version, range));
+}
+
+export function satisfiesOpenClawCompatibilityRange({ targetVersion, eligibilityVersion, range }) {
+  try {
+    return new semver.Range(range).set.some((comparators) => {
+      const branch = comparators.map((comparator) => comparator.value).filter(Boolean).join(" ") || "*";
+      if (semver.satisfies(targetVersion, branch)) return true;
+      const includesPrerelease = comparators.some(
+        (comparator) => (comparator.semver?.prerelease?.length ?? 0) > 0,
+      );
+      return !includesPrerelease && semver.satisfies(eligibilityVersion, branch);
+    });
+  } catch {
+    return false;
+  }
+}
+
+async function preparePackageArchive(resolvedTarget, options) {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const response = await fetchImpl(downloadUrlFor(resolvedTarget));
+  if (!response.ok) {
+    throw new Error(`failed to download OpenClaw ${resolvedTarget.version}: HTTP ${response.status}`);
+  }
+  const archive = Buffer.from(await response.arrayBuffer());
+  verifyArchive(archive, resolvedTarget.source);
+
+  await mkdir(path.dirname(options.targetDir), { recursive: true });
+  const temporaryDir = await mkdtemp(path.join(path.dirname(options.targetDir), `.${path.basename(options.targetDir)}-`));
+  try {
+    const archivePath = path.join(temporaryDir, "openclaw.tgz");
+    await writeFile(archivePath, archive);
+    await extractTar({ cwd: temporaryDir, file: archivePath, strict: true });
+    const packageDir = path.join(temporaryDir, "package");
+    if (!(await isPreparedPackage(packageDir, resolvedTarget.version))) {
+      throw new Error(`downloaded OpenClaw ${resolvedTarget.version} archive has unexpected package metadata`);
+    }
+    await rm(archivePath, { force: true });
+    try {
+      await rename(temporaryDir, options.targetDir);
+    } catch (error) {
+      if (error?.code !== "EEXIST" && error?.code !== "ENOTEMPTY") throw error;
+    }
+  } finally {
+    await rm(temporaryDir, { recursive: true, force: true });
+  }
+}
+
+async function isPreparedPackage(packageDir, version) {
+  if (!existsSync(path.join(packageDir, "package.json"))) return false;
+  try {
+    const packageJson = JSON.parse(await readFile(path.join(packageDir, "package.json"), "utf8"));
+    return packageJson.name === "openclaw" && packageJson.version === version;
+  } catch {
+    return false;
+  }
+}
+
+function verifyArchive(archive, source) {
+  if (typeof source.integrity === "string" && source.integrity.startsWith("sha512-")) {
+    const actual = createHash("sha512").update(archive).digest("base64");
+    if (actual !== source.integrity.slice("sha512-".length)) throw new Error("OpenClaw npm archive failed integrity verification");
+    return;
+  }
+  if (typeof source.shasum === "string" && /^[a-f0-9]{40}$/i.test(source.shasum)) {
+    const actual = createHash("sha1").update(archive).digest("hex");
+    if (actual !== source.shasum.toLowerCase()) throw new Error("OpenClaw npm archive failed shasum verification");
+    return;
+  }
+  throw new Error("OpenClaw npm archive has no supported integrity metadata");
+}
+
+async function fetchJson(url, fetchImpl) {
+  const response = await fetchImpl(url, { headers: { accept: "application/json" } });
+  if (!response.ok) throw new Error(`failed to resolve OpenClaw npm metadata: HTTP ${response.status}`);
+  return response.json();
+}
+
+function cacheKeyFor(target) {
+  const identity = target.source.integrity ?? target.source.shasum ?? target.source.tarball;
+  const digest = createHash("sha256").update(String(identity)).digest("hex").slice(0, 12);
+  return `${target.version}-${digest}`;
+}
+
+function downloadUrlFor(target) {
+  return downloadUrls.get(target) ?? null;
+}
+
+function hasVerifiableIntegrity(dist) {
+  return (
+    (typeof dist.integrity === "string" && /^sha512-[A-Za-z0-9+/]+=*$/.test(dist.integrity)) ||
+    (typeof dist.shasum === "string" && /^[a-f0-9]{40}$/i.test(dist.shasum))
+  );
+}
+
+function isExactOpenClawVersion(value) {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(value) && semver.valid(value) === value;
+}
+
+function normalizeRegistryUrl(value) {
+  return String(value).replace(/\/+$/, "");
+}
+
+function sanitizeUrlForReport(value) {
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeRepositoryForReport(repository) {
+  if (typeof repository === "string") return sanitizeUrlForReport(repository);
+  if (!repository || typeof repository !== "object") return null;
+  return {
+    ...repository,
+    url: typeof repository.url === "string" ? sanitizeUrlForReport(repository.url) : null,
+  };
+}

--- a/src/report.js
+++ b/src/report.js
@@ -110,6 +110,7 @@ export async function buildCompatibilityReport(options = {}) {
       fixtureReport,
       targetOpenClaw,
     });
+    breakages.push(...fixtureClassification.breakages);
     warnings.push(...fixtureClassification.warnings);
     suggestions.push(...fixtureClassification.suggestions);
     logs.push(...fixtureClassification.logs);

--- a/test/openclaw-version.test.js
+++ b/test/openclaw-version.test.js
@@ -9,6 +9,7 @@ import { c as createTar } from "tar";
 import { promisify } from "node:util";
 import { test } from "node:test";
 import {
+  openClawEligibilityVersion,
   prepareOpenClawTarget,
   resolveOpenClawTargetVersion,
   satisfiesOpenClawCompatibilityRange,
@@ -17,6 +18,10 @@ import {
 
 const execFileAsync = promisify(execFile);
 const affectedBeta = "2026.7.2-beta.4";
+
+test("eligibility normalization leaves invalid version-like input unchanged", () => {
+  assert.equal(openClawEligibilityVersion("not-a-version-beta.4"), "not-a-version-beta.4");
+});
 
 test("official OpenClaw tags resolve to exact versions and prepared targets reuse the cache", async (t) => {
   const fixture = await createRegistryFixture(t);

--- a/test/openclaw-version.test.js
+++ b/test/openclaw-version.test.js
@@ -1,0 +1,362 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { c as createTar } from "tar";
+import { promisify } from "node:util";
+import { test } from "node:test";
+import {
+  prepareOpenClawTarget,
+  resolveOpenClawTargetVersion,
+  satisfiesOpenClawCompatibilityRange,
+  satisfiesOpenClawVersionRange,
+} from "../src/advanced.js";
+
+const execFileAsync = promisify(execFile);
+const affectedBeta = "2026.7.2-beta.4";
+
+test("official OpenClaw tags resolve to exact versions and prepared targets reuse the cache", async (t) => {
+  const fixture = await createRegistryFixture(t);
+
+  const latest = await resolveOpenClawTargetVersion("latest", { registryUrl: fixture.registryUrl });
+  const beta = await resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl });
+  await assert.rejects(
+    () => prepareOpenClawTarget(JSON.parse(JSON.stringify(beta)), { cacheDir: fixture.cacheDir }),
+    /directly returned by resolveOpenClawTargetVersion/,
+  );
+  const first = await prepareOpenClawTarget(beta, { cacheDir: fixture.cacheDir });
+  const second = await prepareOpenClawTarget(beta, { cacheDir: fixture.cacheDir });
+
+  assert.equal(latest.version, "2026.7.1-2");
+  assert.equal(latest.eligibilityVersion, "2026.7.1");
+  assert.equal(latest.source.distTag, "latest");
+  assert.equal(beta.version, affectedBeta);
+  assert.equal(beta.source.distTag, "beta");
+  assert.equal(beta.source.tarball.includes("fixture-secret"), false);
+  assert.equal(JSON.stringify(beta).includes("fixture-secret"), false);
+  assert.equal(first.version, affectedBeta);
+  assert.deepEqual(first.apiRegistrars, ["registerCli", "registerTool"]);
+  assert.equal(first.cache.hit, false);
+  assert.equal(second.cache.hit, true);
+  assert.equal(fixture.requests.filter((request) => request.startsWith(`/openclaw/-/openclaw-${affectedBeta}.tgz`)).length, 1);
+});
+
+test("targets without verifiable npm integrity metadata are rejected", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  fixture.distMetadata.integrity = null;
+  fixture.distMetadata.shasum = null;
+
+  await assert.rejects(
+    () => resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl }),
+    /verifiable integrity metadata/,
+  );
+});
+
+test("registry-controlled dist-tags cannot escape the target cache", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  fixture.distTags.beta = "../../outside";
+
+  await assert.rejects(
+    () => resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl }),
+    /did not resolve to a valid exact version/,
+  );
+});
+
+test("declared compatibility uses complete npm semver range syntax", () => {
+  assert.equal(satisfiesOpenClawVersionRange("2026.7.1", "2026.3.22 - 2026.7.1"), true);
+  assert.equal(satisfiesOpenClawVersionRange("2026.7.1", "2026.7"), true);
+  assert.equal(satisfiesOpenClawVersionRange("2026.7.1", "2026.x"), true);
+  assert.equal(
+    satisfiesOpenClawCompatibilityRange({
+      targetVersion: affectedBeta,
+      eligibilityVersion: "2026.7.2",
+      range: ">=2026.7.2 || >=2026.8.0-beta.1",
+    }),
+    true,
+  );
+  assert.equal(
+    satisfiesOpenClawCompatibilityRange({
+      targetVersion: affectedBeta,
+      eligibilityVersion: "2026.7.2",
+      range: ">=2026.7.2-beta.5 <2026.7.2 || >=2026.8.0",
+    }),
+    false,
+  );
+});
+
+test("public CLI reports Honcho memory registrars as errors against the affected exact beta", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  const pluginRoot = await createHonchoPlugin(t, ">=2026.3.22");
+  const cliPath = path.resolve("src/cli.js");
+
+  await execFileAsync(
+    process.execPath,
+    [cliPath, "inspect", "--plugin-root", pluginRoot, "--out", "reports", "--openclaw-version", affectedBeta],
+    {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        PLUGIN_INSPECTOR_CACHE_DIR: fixture.cacheDir,
+        PLUGIN_INSPECTOR_NPM_REGISTRY: fixture.registryUrl,
+      },
+    },
+  );
+
+  const report = JSON.parse(await readFile(path.join(pluginRoot, "reports", "plugin-inspector-report.json"), "utf8"));
+  const finding = report.breakages.find((item) => item.code === "unknown-registration-name");
+  const issue = report.issues.find((item) => item.code === "unknown-registration-name");
+
+  assert.equal(report.status, "fail");
+  assert.equal(report.targetOpenClaw.requestedVersion, affectedBeta);
+  assert.equal(report.targetOpenClaw.version, affectedBeta);
+  assert.equal(report.targetOpenClaw.eligibilityVersion, "2026.7.2");
+  assert.equal(report.targetOpenClaw.source.package, "openclaw");
+  assert.equal(report.fixtures[0].package.openclaw.compatPluginApi, ">=2026.3.22");
+  assert.deepEqual(finding.evidence.map((item) => item.split(" @ ")[0]), [
+    "registerMemoryPromptSection",
+    "registerMemoryRuntime",
+  ]);
+  assert.match(issue.authorRemediation.summary, /available in the target OpenClaw version/i);
+  assert.equal("docsUrl" in issue.authorRemediation, false);
+});
+
+test("version-derived API removals outside the declared range remain informational", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  const pluginRoot = await createHonchoPlugin(t, "<2026.7.2");
+  const cliPath = path.resolve("src/cli.js");
+
+  await execFileAsync(
+    process.execPath,
+    [cliPath, "inspect", "--plugin-root", pluginRoot, "--out", "reports", "--openclaw-version", affectedBeta],
+    {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        PLUGIN_INSPECTOR_CACHE_DIR: fixture.cacheDir,
+        PLUGIN_INSPECTOR_NPM_REGISTRY: fixture.registryUrl,
+      },
+    },
+  );
+
+  const report = JSON.parse(await readFile(path.join(pluginRoot, "reports", "plugin-inspector-report.json"), "utf8"));
+  const finding = report.suggestions.find((item) => item.code === "unknown-registration-name");
+
+  assert.equal(report.status, "pass");
+  assert.equal(report.breakages.some((item) => item.code === "unknown-registration-name"), false);
+  assert.equal(finding.compatibility.inDeclaredRange, false);
+  assert.equal(finding.compatibility.declaredRange, "<2026.7.2");
+  assert.equal(finding.compatibility.evaluatedVersion, "2026.7.2");
+});
+
+test("the affected exact beta remains eligible when the declared range names that prerelease", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  const pluginRoot = await createHonchoPlugin(t, affectedBeta);
+  const cliPath = path.resolve("src/cli.js");
+
+  await execFileAsync(
+    process.execPath,
+    [cliPath, "inspect", "--plugin-root", pluginRoot, "--out", "reports", "--openclaw-version", affectedBeta],
+    {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        PLUGIN_INSPECTOR_CACHE_DIR: fixture.cacheDir,
+        PLUGIN_INSPECTOR_NPM_REGISTRY: fixture.registryUrl,
+      },
+    },
+  );
+
+  const report = JSON.parse(await readFile(path.join(pluginRoot, "reports", "plugin-inspector-report.json"), "utf8"));
+  const finding = report.breakages.find((item) => item.code === "unknown-registration-name");
+
+  assert.equal(report.status, "fail");
+  assert.equal(finding.compatibility.targetVersion, affectedBeta);
+  assert.equal(finding.compatibility.inDeclaredRange, true);
+});
+
+test("stable eligibility does not override a range requiring a later prerelease", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  const pluginRoot = await createHonchoPlugin(t, ">=2026.7.2-beta.5 <2026.7.2");
+  const cliPath = path.resolve("src/cli.js");
+
+  await execFileAsync(
+    process.execPath,
+    [cliPath, "inspect", "--plugin-root", pluginRoot, "--out", "reports", "--openclaw-version", affectedBeta],
+    {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        PLUGIN_INSPECTOR_CACHE_DIR: fixture.cacheDir,
+        PLUGIN_INSPECTOR_NPM_REGISTRY: fixture.registryUrl,
+      },
+    },
+  );
+
+  const report = JSON.parse(await readFile(path.join(pluginRoot, "reports", "plugin-inspector-report.json"), "utf8"));
+  const finding = report.suggestions.find((item) => item.code === "unknown-registration-name");
+
+  assert.equal(report.status, "pass");
+  assert.equal(finding.compatibility.targetVersion, affectedBeta);
+  assert.equal(finding.compatibility.inDeclaredRange, false);
+});
+
+test("public CLI rejects an openclaw-version flag without a value", async () => {
+  const cliPath = path.resolve("src/cli.js");
+  await assert.rejects(
+    () => execFileAsync(process.execPath, [cliPath, "inspect", "--openclaw-version"]),
+    (error) => {
+      assert.match(error.stderr, /--openclaw-version requires a value/);
+      return true;
+    },
+  );
+});
+
+test("batch CLI prepares one resolved beta target for multiple plugin inspections", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  const corpusRoot = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-version-batch-"));
+  t.after(() => rm(corpusRoot, { recursive: true, force: true }));
+  await writeHonchoPlugin(path.join(corpusRoot, "honcho-a"), ">=2026.3.22");
+  await writeHonchoPlugin(path.join(corpusRoot, "honcho-b"), ">=2026.3.22");
+  const cliPath = path.resolve("src/cli.js");
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [cliPath, "batch", corpusRoot, "--out", "reports", "--openclaw-version", "beta", "--json"],
+    {
+      env: {
+        ...process.env,
+        PLUGIN_INSPECTOR_CACHE_DIR: fixture.cacheDir,
+        PLUGIN_INSPECTOR_NPM_REGISTRY: fixture.registryUrl,
+      },
+    },
+  );
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.summary.pluginCount, 2);
+  assert.ok(report.plugins.every((plugin) => plugin.targetOpenClaw.version === affectedBeta));
+  assert.equal(fixture.requests.filter((request) => request.startsWith(`/openclaw/-/openclaw-${affectedBeta}.tgz`)).length, 1);
+});
+
+async function createHonchoPlugin(t, compatibilityRange) {
+  const pluginRoot = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-honcho-"));
+  t.after(() => rm(pluginRoot, { recursive: true, force: true }));
+  await writeHonchoPlugin(pluginRoot, compatibilityRange);
+  return pluginRoot;
+}
+
+async function writeHonchoPlugin(pluginRoot, compatibilityRange) {
+  await mkdir(pluginRoot, { recursive: true });
+  await writeFile(
+    path.join(pluginRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "@fixture/openclaw-honcho",
+        version: "1.0.0",
+        type: "module",
+        openclaw: {
+          extensions: ["./index.js"],
+          compat: { pluginApi: compatibilityRange },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    `${JSON.stringify({ id: "honcho", name: "Honcho", version: "1.0.0" }, null, 2)}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(pluginRoot, "index.js"),
+    [
+      "export function register(api) {",
+      "  api.registerMemoryPromptSection(() => []);",
+      "  api.registerMemoryRuntime({ id: 'honcho' });",
+      "}",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+async function createRegistryFixture(t) {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-registry-"));
+  const cacheDir = path.join(rootDir, "cache");
+  const packageRoot = path.join(rootDir, "archive", "package");
+  const tarballPath = path.join(rootDir, `openclaw-${affectedBeta}.tgz`);
+  await mkdir(path.join(packageRoot, "dist", "plugin-sdk"), { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "openclaw",
+        version: affectedBeta,
+        exports: { "./plugin-sdk": { types: "./dist/plugin-sdk/index.d.ts", import: "./dist/plugin-sdk/index.js" } },
+        repository: { type: "git", url: "git+https://github.com/openclaw/openclaw.git" },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(packageRoot, "dist", "plugin-sdk", "index.d.ts"),
+    'type PluginHookName = "before_prompt_build" | "agent_end"; type OpenClawPluginApi = { id: string; /** compact declaration */ registerTool: (tool: unknown) => void; registerCli: (registrar: { registerNested: () => void }) => void; };',
+    "utf8",
+  );
+  await createTar({ cwd: path.join(rootDir, "archive"), file: tarballPath, gzip: true }, ["package"]);
+  const archive = await readFile(tarballPath);
+
+  const requests = [];
+  const distTags = { latest: "2026.7.1-2", beta: affectedBeta };
+  const distMetadata = {
+    integrity: `sha512-${createHash("sha512").update(archive).digest("base64")}`,
+    shasum: createHash("sha1").update(archive).digest("hex"),
+  };
+  const server = createServer(async (request, response) => {
+    requests.push(request.url);
+    const requestUrl = new URL(request.url, registryUrl(server));
+    if (requestUrl.pathname === "/openclaw") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ "dist-tags": distTags }));
+      return;
+    }
+    if (requestUrl.pathname === `/openclaw/${affectedBeta}` || requestUrl.pathname === "/openclaw/2026.7.1-2") {
+      const version = requestUrl.pathname.endsWith("2026.7.1-2") ? "2026.7.1-2" : affectedBeta;
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          name: "openclaw",
+          version,
+          dist: {
+            tarball: `${registryUrl(server)}/openclaw/-/openclaw-${version}.tgz?token=fixture-secret`,
+            ...distMetadata,
+          },
+          repository: { type: "git", url: "git+https://github.com/openclaw/openclaw.git" },
+        }),
+      );
+      return;
+    }
+    if (requestUrl.pathname === `/openclaw/-/openclaw-${affectedBeta}.tgz`) {
+      response.setHeader("content-type", "application/octet-stream");
+      response.end(await readFile(tarballPath));
+      return;
+    }
+    response.statusCode = 404;
+    response.end("not found");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+  t.after(() => rm(rootDir, { recursive: true, force: true }));
+
+  return { cacheDir, distMetadata, distTags, registryUrl: registryUrl(server), requests };
+}
+
+function registryUrl(server) {
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}`;
+}

--- a/test/openclaw-version.test.js
+++ b/test/openclaw-version.test.js
@@ -87,6 +87,17 @@ test("declared compatibility uses complete npm semver range syntax", () => {
   );
 });
 
+test("beta eligibility preserves historical prerelease lower bounds", () => {
+  assert.equal(
+    satisfiesOpenClawCompatibilityRange({
+      targetVersion: affectedBeta,
+      eligibilityVersion: "2026.7.2",
+      range: ">=2026.3.24-beta.2",
+    }),
+    true,
+  );
+});
+
 test("public CLI reports Honcho memory registrars as errors against the affected exact beta", async (t) => {
   const fixture = await createRegistryFixture(t);
   const pluginRoot = await createHonchoPlugin(t, ">=2026.3.22");


### PR DESCRIPTION
## Summary

- add public `--openclaw-version latest|beta|<exact>` support across Plugin Inspector workflows
- resolve and integrity-check official npm targets, cache prepared packages, and parse public packed declarations
- classify version-derived API removals against declared compatibility ranges, including upcoming-stable beta eligibility
- keep out-of-range targets informational and omit fabricated remediation URLs

## Validation

- `npm run check` — 227 tests passed; package contents passed (59 entries)
- `node --test test/openclaw-version.test.js test/openclaw-target.test.js test/issues.test.js` — 20 tests passed
- autoreview branch diff against `origin/main` — clean, no accepted/actionable findings
- real `openclaw@2026.7.2-beta.4` npm target detected Honcho's removed memory registrars with cache miss-to-hit reuse
- Crabpot source-mode and package-mode smoke commands completed with the existing fixture baseline
