### PR TITLE
fix: accept BOM-prefixed plugin manifests

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -195,7 +195,8 @@ async function readJsonIfExists(filePath) {
   if (!existsSync(filePath)) {
     return null;
   }
-  return JSON.parse(await readFile(filePath, "utf8"));
+  const contents = await readFile(filePath, "utf8");
+  return JSON.parse(contents.startsWith("\uFEFF") ? contents.slice(1) : contents);
 }
 
 export function packageId(packageName) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -157,6 +157,33 @@ test("public API reads plugin config from package.json", async () => {
   assert.equal(config.capture.mockSdk, true);
 });
 
+test("public API reads a package.json with one leading UTF-8 BOM", async () => {
+  const pluginRoot = await createPluginRoot();
+  const packageJsonPath = path.join(pluginRoot, "package.json");
+  const packageJson = await readFile(packageJsonPath, "utf8");
+  await writeFile(packageJsonPath, `\uFEFF${packageJson}`, "utf8");
+
+  const config = await loadPluginConfig({ pluginRoot });
+
+  assert.equal(config.fixtures[0].id, "weather");
+});
+
+test("public API still rejects invalid package.json after BOM compatibility handling", async () => {
+  const pluginRoot = await createPluginRoot();
+  await writeFile(path.join(pluginRoot, "package.json"), '{"name":', "utf8");
+
+  await assert.rejects(loadPluginConfig({ pluginRoot }), SyntaxError);
+});
+
+test("public API strips only one leading UTF-8 BOM from package.json", async () => {
+  const pluginRoot = await createPluginRoot();
+  const packageJsonPath = path.join(pluginRoot, "package.json");
+  const packageJson = await readFile(packageJsonPath, "utf8");
+  await writeFile(packageJsonPath, `\uFEFF\uFEFF${packageJson}`, "utf8");
+
+  await assert.rejects(loadPluginConfig({ pluginRoot }), SyntaxError);
+});
+
 test("public API keeps crabpot-style fixture configs behind an explicit helper", async () => {
   const report = await inspectFixtureSetConfig({ configPath: "test/fixtures/inspector.config.json" });
 


### PR DESCRIPTION
## Summary

- accept exactly one leading UTF-8 BOM when Plugin Inspector reads a plugin-root JSON manifest
- preserve native `SyntaxError` behavior for malformed JSON and multiple leading BOMs
- cover the public plugin-root config seam with regression tests

## Validation

- `node --test test/api.test.js --test-name-pattern='UTF-8 BOM|invalid package.json'`
- `npm run check`
- structured autoreview: clean, no accepted/actionable findings
