### PR TITLE
fix: avoid plugin compatibility false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.20 - 2026-07-31
 
 ### Added
 
@@ -10,6 +10,8 @@
 
 - Treat version-derived API removals inside a plugin's declared OpenClaw range as author-facing errors while keeping out-of-range targets informational, including beta eligibility against the upcoming stable version.
 - Accept tested minimum OpenClaw host versions below a plugin's build version without reporting package metadata drift.
+- Ignore type-only OpenClaw SDK imports when classifying runtime compatibility against a target release.
+- Accept `openclaw.runtimeSetupEntry` and other paired compiled runtime entrypoints as valid replacements for absent source entrypoints.
 
 ## 0.3.19 - 2026-07-27
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/plugin-inspector",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "private": false,
   "description": "Offline compatibility inspector for OpenClaw plugins.",
   "type": "module",

--- a/src/fixture-summary.js
+++ b/src/fixture-summary.js
@@ -144,6 +144,8 @@ export function summarizePackage(packagePath, packageJson, options = {}) {
         extensions: arrayValues(packageJson.openclaw.extensions),
         runtimeExtensions: arrayValues(packageJson.openclaw.runtimeExtensions),
         setupEntry: typeof packageJson.openclaw.setupEntry === "string" ? packageJson.openclaw.setupEntry : null,
+        runtimeSetupEntry:
+          typeof packageJson.openclaw.runtimeSetupEntry === "string" ? packageJson.openclaw.runtimeSetupEntry : null,
         compatPluginApi:
           typeof packageJson.openclaw.compat?.pluginApi === "string" ? packageJson.openclaw.compat.pluginApi : null,
         buildOpenClawVersion:
@@ -1043,6 +1045,9 @@ function collectOpenClawEntrypoints(packageDir, openclaw, options) {
     ...openclaw.extensions.map((specifier) => ({ kind: "extension", specifier })),
     ...openclaw.runtimeExtensions.map((specifier) => ({ kind: "runtimeExtension", specifier })),
     ...(openclaw.setupEntry ? [{ kind: "setupEntry", specifier: openclaw.setupEntry }] : []),
+    ...(openclaw.runtimeSetupEntry
+      ? [{ kind: "runtimeSetupEntry", specifier: openclaw.runtimeSetupEntry }]
+      : []),
   ];
 
   return entrypoints.map((entrypoint) => {
@@ -1074,7 +1079,7 @@ function hasUsablePackageRuntimeEntrypoint(entrypoint, packageSummary, entrypoin
     return true;
   }
 
-  if (entrypoint.kind === "extension" && entrypoints.some((candidate) => candidate.kind === "runtimeExtension" && candidate.exists)) {
+  if (entrypoints.some((candidate) => candidate.exists && isPairedRuntimeEntrypoint(entrypoint, candidate))) {
     return true;
   }
 
@@ -1095,6 +1100,13 @@ function runtimeBuildSpecifierFor(specifier) {
 function normalizeEntrypointSpecifier(specifier) {
   const normalized = specifier.replaceAll("\\", "/");
   return normalized.startsWith("./") ? normalized : `./${normalized}`;
+}
+
+function isPairedRuntimeEntrypoint(entrypoint, candidate) {
+  return (
+    (entrypoint.kind === "extension" && candidate.kind === "runtimeExtension") ||
+    (entrypoint.kind === "setupEntry" && candidate.kind === "runtimeSetupEntry")
+  );
 }
 
 async function findPackageFiles(root, options, depth = 0) {
@@ -1286,9 +1298,10 @@ function hasPackagedRuntimeEntrypoint(entrypoint, packageSummary, entrypoints) {
   }
 
   if (
-    entrypoint.kind === "extension" &&
     entrypoints.some(
-      (candidate) => candidate.kind === "runtimeExtension" && repoPathIncludedInNpmPack(packageSummary, candidate.relativePath),
+      (candidate) =>
+        isPairedRuntimeEntrypoint(entrypoint, candidate) &&
+        repoPathIncludedInNpmPack(packageSummary, candidate.relativePath),
     )
   ) {
     return true;

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
+import * as nodeModule from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
@@ -168,12 +169,7 @@ export function inspectSourceText(text, filePath = "source.js") {
     ...collectDetailedMatches(searchableText, /\b(createChatChannelPlugin)\s*\(/g, filePath, "name"),
     ...collectDetailedMatches(searchableText, /\b(definePluginEntry)\s*\(/g, filePath, "name"),
   ];
-  const sdkImports = collectDetailedMatches(
-    searchableText,
-    /(?:from\s*["'`]|import\(\s*["'`])([^"'`]*openclaw\/plugin-sdk[^"'`]*)/g,
-    filePath,
-    "specifier",
-  );
+  const sdkImports = collectSdkImports(searchableText, filePath);
   const sdkDeprecations = inspectSdkDeprecations(searchableText, filePath);
 
   return {
@@ -388,6 +384,105 @@ function collectDetailedMatches(text, regex, filePath, key) {
   return details;
 }
 
+function collectSdkImports(text, filePath) {
+  const details = [];
+  const staticDeclaration =
+    /(?:^|;)[\t ]*(?:import|export)\s+((?:type\s+)?(?:\{[\s\S]*?\}|\*\s*(?:as\s+[A-Za-z_$][\w$]*)?|[A-Za-z_$][\w$]*(?:\s*,\s*(?:\{[\s\S]*?\}|\*\s+as\s+[A-Za-z_$][\w$]*))?))\s+from\s*["'`]([^"'`]*openclaw\/plugin-sdk[^"'`]*)["'`]/gm;
+  for (const match of text.matchAll(staticDeclaration)) {
+    if (isTypeOnlyStaticImportClause(match[1])) continue;
+    const line = lineForOffset(text, match.index ?? 0);
+    details.push({
+      specifier: match[2],
+      file: filePath,
+      line,
+      ref: `${filePath}:${line}`,
+    });
+  }
+
+  const dynamicMatches = [...text.matchAll(/\bimport\(\s*["'`]([^"'`]*openclaw\/plugin-sdk[^"'`]*)/g)];
+  const runtimeDynamicImports = runtimeDynamicImportIndexes(text, dynamicMatches);
+  for (const [index, match] of dynamicMatches.entries()) {
+    if (!runtimeDynamicImports.has(index)) continue;
+    const line = lineForOffset(text, match.index ?? 0);
+    details.push({
+      specifier: match[1],
+      file: filePath,
+      line,
+      ref: `${filePath}:${line}`,
+    });
+  }
+  return details.sort((left, right) => left.line - right.line || left.specifier.localeCompare(right.specifier));
+}
+
+function runtimeDynamicImportIndexes(text, matches) {
+  if (matches.length === 0) return new Set();
+  const markedImports = matches.map((match, index) => {
+    const specifier = match[1];
+    const specifierStart = (match.index ?? 0) + match[0].indexOf(specifier);
+    return {
+      index,
+      specifierStart,
+      specifierEnd: specifierStart + specifier.length,
+      marker: `${specifier}/__plugin_inspector_runtime_import_${index}__`,
+    };
+  });
+  let markedText = text;
+  for (const markedImport of markedImports.toReversed()) {
+    markedText =
+      markedText.slice(0, markedImport.specifierStart) +
+      markedImport.marker +
+      markedText.slice(markedImport.specifierEnd);
+  }
+
+  try {
+    const runtimeText = eraseTypeScript(markedText);
+    if (runtimeText === null) {
+      return new Set(markedImports.map((markedImport) => markedImport.index));
+    }
+    return new Set(
+      markedImports.filter((markedImport) => runtimeText.includes(markedImport.marker)).map((markedImport) => markedImport.index),
+    );
+  } catch {
+    return new Set(markedImports.map((markedImport) => markedImport.index));
+  }
+}
+
+function eraseTypeScript(text) {
+  if (typeof nodeModule.stripTypeScriptTypes === "function") {
+    return nodeModule.stripTypeScriptTypes(text, { mode: "transform" });
+  }
+  if (typeof globalThis.Bun?.Transpiler === "function") {
+    const transpiler = new globalThis.Bun.Transpiler({ loader: "ts", target: "bun" });
+    return transpiler.transformSync(text);
+  }
+  return null;
+}
+
+function isTypeOnlyStaticImportClause(clause) {
+  clause = clause.trim();
+  if (/^type\b/.test(clause)) {
+    const typeOnlyClause = clause.slice("type".length).trimStart();
+    return typeOnlyClause.length > 0 && !typeOnlyClause.startsWith(",");
+  }
+  if (!clause.startsWith("{") || !clause.endsWith("}")) {
+    return false;
+  }
+
+  const namedImports = clause
+    .slice(1, -1)
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .filter(Boolean);
+  return namedImports.length > 0 && namedImports.every(isTypeOnlyNamedImport);
+}
+
+function isTypeOnlyNamedImport(specifier) {
+  const typeModifier = /^type\b/.exec(specifier);
+  if (!typeModifier) return false;
+  const importedName = specifier.slice(typeModifier[0].length).trimStart();
+  return importedName.length > 0 && !/^as\b/.test(importedName);
+}
+
 async function readManifestContracts(config, checkoutPath, sourceRoot) {
   const manifests = new Set(
     [path.join(sourceRoot, "openclaw.plugin.json"), path.join(checkoutPath, "openclaw.plugin.json")].filter(
@@ -439,6 +534,7 @@ async function readPackageMetadata(config, checkoutPath, sourceRoot) {
       collectEntrypoint(entrypoints, entrypointFiles, packageDir, packageJson.openclaw?.entry);
       collectEntrypoint(entrypoints, entrypointFiles, packageDir, packageJson.openclaw?.entrypoint);
       collectEntrypoint(entrypoints, entrypointFiles, packageDir, packageJson.openclaw?.setupEntry);
+      collectEntrypoint(entrypoints, entrypointFiles, packageDir, packageJson.openclaw?.runtimeSetupEntry);
       collectEntrypoint(entrypoints, entrypointFiles, packageDir, packageJson.exports?.["."]?.import);
       collectEntrypoint(entrypoints, entrypointFiles, packageDir, packageJson.exports?.["."]?.default);
       collectEntrypoints(entrypoints, entrypointFiles, packageDir, packageJson.openclaw?.extensions);

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -386,13 +386,15 @@ function collectDetailedMatches(text, regex, filePath, key) {
 
 function collectSdkImports(text, filePath) {
   const details = [];
-  const staticDeclaration =
-    /(?:^|;)[\t ]*(?:import|export)\s+((?:type\s+)?(?:\{[\s\S]*?\}|\*\s*(?:as\s+[A-Za-z_$][\w$]*)?|[A-Za-z_$][\w$]*(?:\s*,\s*(?:\{[\s\S]*?\}|\*\s+as\s+[A-Za-z_$][\w$]*))?))\s+from\s*["'`]([^"'`]*openclaw\/plugin-sdk[^"'`]*)["'`]/gm;
-  for (const match of text.matchAll(staticDeclaration)) {
-    if (isTypeOnlyStaticImportClause(match[1])) continue;
-    const line = lineForOffset(text, match.index ?? 0);
+  for (const candidate of text.matchAll(/(?:^|;)[\t ]*(import|export)\b/gm)) {
+    const keyword = candidate[1];
+    const keywordIndex = (candidate.index ?? 0) + candidate[0].lastIndexOf(keyword);
+    const declaration = parseStaticModuleDeclaration(text, keywordIndex, keyword);
+    if (!declaration?.specifier.includes("openclaw/plugin-sdk")) continue;
+    if (isTypeOnlyStaticImportClause(declaration.clause)) continue;
+    const line = lineForOffset(text, keywordIndex);
     details.push({
-      specifier: match[2],
+      specifier: declaration.specifier,
       file: filePath,
       line,
       ref: `${filePath}:${line}`,
@@ -412,6 +414,64 @@ function collectSdkImports(text, filePath) {
     });
   }
   return details.sort((left, right) => left.line - right.line || left.specifier.localeCompare(right.specifier));
+}
+
+function parseStaticModuleDeclaration(text, keywordIndex, keyword) {
+  const clauseStart = keywordIndex + keyword.length;
+  let cursor = skipWhitespace(text, clauseStart);
+  if (text[cursor] === "(") return null;
+  if (keyword === "export" && text[cursor] !== "{" && text[cursor] !== "*" && !hasWordAt(text, cursor, "type")) {
+    return null;
+  }
+
+  let braceDepth = 0;
+  while (cursor < text.length) {
+    const char = text[cursor];
+    if (char === '"' || char === "'" || char === "`") {
+      cursor = skipQuotedText(text, cursor, char);
+      continue;
+    }
+    if (char === "{") braceDepth += 1;
+    if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    if (char === ";" && braceDepth === 0) return null;
+    if (braceDepth === 0 && hasWordAt(text, cursor, "from")) {
+      const clause = text.slice(clauseStart, cursor).trim();
+      cursor = skipWhitespace(text, cursor + "from".length);
+      const quote = text[cursor];
+      if (quote !== '"' && quote !== "'" && quote !== "`") return null;
+      const specifierStart = cursor + 1;
+      const specifierEnd = skipQuotedText(text, cursor, quote) - 1;
+      return { clause, specifier: text.slice(specifierStart, specifierEnd) };
+    }
+    cursor += 1;
+  }
+  return null;
+}
+
+function skipWhitespace(text, index) {
+  while (index < text.length && /\s/.test(text[index])) index += 1;
+  return index;
+}
+
+function hasWordAt(text, index, word) {
+  return (
+    text.startsWith(word, index) &&
+    !/[A-Za-z0-9_$]/.test(text[index - 1] ?? "") &&
+    !/[A-Za-z0-9_$]/.test(text[index + word.length] ?? "")
+  );
+}
+
+function skipQuotedText(text, quoteIndex, quote) {
+  let cursor = quoteIndex + 1;
+  while (cursor < text.length) {
+    if (text[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    cursor += 1;
+    if (text[cursor - 1] === quote) break;
+  }
+  return cursor;
 }
 
 function runtimeDynamicImportIndexes(text, matches) {

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -5,7 +5,7 @@ import path from "node:path";
 import { test } from "node:test";
 import { captureEntrypoint, inspectFixtureSet, inspectSourceText, loadInspectorConfig } from "../src/advanced.js";
 
-test("source inspection records hook, registrar, and SDK import evidence", () => {
+test("source inspection records hooks and registrars without treating type-only SDK imports as runtime imports", () => {
   const inspection = inspectSourceText(
     [
       'import type { OpenClawPluginApi } from "openclaw/plugin-sdk";',
@@ -33,14 +33,89 @@ test("source inspection records hook, registrar, and SDK import evidence", () =>
     inspection.registrations.map((registration) => `${registration.name}@${registration.ref}`),
     ["registerService@plugins/example/index.ts:7", "definePluginEntry@plugins/example/index.ts:8"],
   );
+  assert.deepEqual(inspection.sdkImports, []);
+});
+
+test("source inspection ignores all type-only OpenClaw SDK import forms", () => {
+  const inspection = inspectSourceText(
+    [
+      'import type { OpenClawPluginApi } from "openclaw/plugin-sdk";',
+      'export type { PluginConfig } from "openclaw/plugin-sdk/config";',
+      'import { type PluginRuntime, } from "openclaw/plugin-sdk/runtime";',
+      'import { type PluginState, definePluginEntry } from "openclaw/plugin-sdk";',
+      'import { type as typeValue } from "openclaw/plugin-sdk/type-value";',
+      'import { type } from "openclaw/plugin-sdk/bare-type-value";',
+      'import { type PluginHook as import } from "openclaw/plugin-sdk/import-alias";',
+      'export { type PluginTool as export } from "openclaw/plugin-sdk/export-alias";',
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
   assert.deepEqual(inspection.sdkImports, [
     {
       specifier: "openclaw/plugin-sdk",
       file: "plugins/example/index.ts",
-      line: 1,
-      ref: "plugins/example/index.ts:1",
+      line: 4,
+      ref: "plugins/example/index.ts:4",
+    },
+    {
+      specifier: "openclaw/plugin-sdk/type-value",
+      file: "plugins/example/index.ts",
+      line: 5,
+      ref: "plugins/example/index.ts:5",
+    },
+    {
+      specifier: "openclaw/plugin-sdk/bare-type-value",
+      file: "plugins/example/index.ts",
+      line: 6,
+      ref: "plugins/example/index.ts:6",
     },
   ]);
+});
+
+test("source inspection keeps runtime default imports whose binding is named type", () => {
+  const inspection = inspectSourceText(
+    [
+      'import type from "openclaw/plugin-sdk/default-type-value";',
+      'import type, { definePluginEntry } from "openclaw/plugin-sdk";',
+      'import type PluginApi from "openclaw/plugin-sdk/types";',
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(
+    inspection.sdkImports.map((sdkImport) => `${sdkImport.specifier}@${sdkImport.ref}`),
+    [
+      "openclaw/plugin-sdk/default-type-value@plugins/example/index.ts:1",
+      "openclaw/plugin-sdk@plugins/example/index.ts:2",
+    ],
+  );
+});
+
+test("source inspection separates compact runtime imports from TypeScript import types", () => {
+  const inspection = inspectSourceText(
+    [
+      'import value from "elsewhere"; import { definePluginEntry } from "openclaw/plugin-sdk";',
+      'type PluginApi = import("openclaw/plugin-sdk").OpenClawPluginApi;',
+      'export type PluginState = import("openclaw/plugin-sdk/config").PluginState;',
+      'const loadRuntime = () => import("openclaw/plugin-sdk/runtime");',
+      'interface Options { api: import("openclaw/plugin-sdk/interface").Api }',
+      'const options: { api: import("openclaw/plugin-sdk/annotation").Api } = { api: null };',
+      'enum Mode { Default }',
+      'type Empty = {}',
+      'const loadSemicolonless = () => import("openclaw/plugin-sdk/semicolonless")',
+    ].join("\n"),
+    "plugins/example/index.ts",
+  );
+
+  assert.deepEqual(
+    inspection.sdkImports.map((sdkImport) => `${sdkImport.specifier}@${sdkImport.ref}`),
+    [
+      "openclaw/plugin-sdk@plugins/example/index.ts:1",
+      "openclaw/plugin-sdk/runtime@plugins/example/index.ts:4",
+      "openclaw/plugin-sdk/semicolonless@plugins/example/index.ts:9",
+    ],
+  );
 });
 
 test("source inspection strips long comments before matching registrations", () => {

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -662,6 +662,7 @@ test("compatibility fixture summary reads manifests and OpenClaw package metadat
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-fixture-summary-"));
   const fixtureDir = path.join(rootDir, "plugin");
   await mkdir(path.join(fixtureDir, "src"), { recursive: true });
+  await mkdir(path.join(fixtureDir, "dist"), { recursive: true });
   await writeFile(
     path.join(fixtureDir, "openclaw.plugin.json"),
     `${JSON.stringify({ id: "fixture", name: "Fixture", version: "1.0.0", contracts: { tools: {} } }, null, 2)}\n`,
@@ -683,6 +684,7 @@ test("compatibility fixture summary reads manifests and OpenClaw package metadat
     "utf8",
   );
   await writeFile(path.join(fixtureDir, "src", "index.js"), "export function register() {}\n", "utf8");
+  await writeFile(path.join(fixtureDir, "dist", "setup-entry.js"), "export function setup() {}\n", "utf8");
   await writeFile(
     path.join(fixtureDir, "package.json"),
     `${JSON.stringify(
@@ -694,6 +696,8 @@ test("compatibility fixture summary reads manifests and OpenClaw package metadat
         dependencies: { zod: "^1.0.0" },
         openclaw: {
           extensions: ["src/index.js"],
+          setupEntry: "src/setup-entry.ts",
+          runtimeSetupEntry: "dist/setup-entry.js",
           compat: { pluginApi: "^1.0.0" },
           build: {
             openclawVersion: "2026.5.2",
@@ -779,6 +783,13 @@ test("compatibility fixture summary reads manifests and OpenClaw package metadat
     relativePath: "plugin/src/index.js",
     exists: true,
     requiresBuild: false,
+  });
+  assert.deepEqual(report.package.openclaw.entrypoints[2], {
+    kind: "runtimeSetupEntry",
+    specifier: "dist/setup-entry.js",
+    relativePath: "plugin/dist/setup-entry.js",
+    exists: true,
+    requiresBuild: true,
   });
   assert.deepEqual(report.sdkImports, ["openclaw/plugin-sdk"]);
 });
@@ -1150,7 +1161,7 @@ test("package contract classifier accepts built runtime entries for source packa
               requiresBuild: false,
             },
             {
-              kind: "runtimeExtension",
+              kind: "runtimeSetupEntry",
               specifier: "./dist/setup-entry.js",
               relativePath: "plugins/fixture/dist/setup-entry.js",
               exists: true,


### PR DESCRIPTION
## Summary
- ignore erased type-only OpenClaw SDK imports while preserving runtime imports under Node and Bun
- accept `runtimeSetupEntry` and paired compiled runtime entrypoints when source entrypoints are absent
- prepare `@openclaw/plugin-inspector@0.3.20`

## Validation
- `npm run check` (234 tests; 59 package-content checks)
- `node --test test/inspector.test.js test/report.test.js` (50 tests)
- Bun source-inspection smoke for type-only versus runtime `import()`
- `git diff --check`
- autoreview: no accepted/actionable findings; one comment-handling finding rejected after direct repro because source comments are stripped before parsing
