### PR TITLE
fix(release): install package dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Verify package
         run: npm run release:local
 


### PR DESCRIPTION
## Summary
- install lockfile-pinned dependencies before the release workflow runs package verification
- unblock the failed `v0.3.20` trusted-publishing run

## Validation
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- autoreview clean

Failed release: https://github.com/openclaw/plugin-inspector/actions/runs/30674780476
