### PR TITLE
test: cover path-utils resolve/join/slug branches

### DIFF
--- a/test/path-utils.test.js
+++ b/test/path-utils.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  normalizeRepoPath,
+  posixJoin,
+  resolveFromRoot,
+  resolveRequiredFromRoot,
+  slugForArtifact,
+  toRepoPath,
+} from "../src/path-utils.js";
+
+test("resolveFromRoot joins a relative value under the root and passes an absolute value through", () => {
+  assert.equal(resolveFromRoot("/root", "sub/file.json"), path.join("/root", "sub/file.json"));
+  assert.equal(resolveFromRoot("/root", "/abs/file.json"), "/abs/file.json");
+});
+
+test("resolveRequiredFromRoot throws a labeled error when the value is missing", () => {
+  assert.throws(() => resolveRequiredFromRoot("/root", "", "config"), {
+    message: "config path is required",
+  });
+  assert.throws(() => resolveRequiredFromRoot("/root", undefined, "workflow"), {
+    message: "workflow path is required",
+  });
+});
+
+test("resolveRequiredFromRoot resolves like resolveFromRoot once a value is present", () => {
+  assert.equal(resolveRequiredFromRoot("/root", "x.json", "config"), path.join("/root", "x.json"));
+  assert.equal(resolveRequiredFromRoot("/root", "/abs/x.json", "config"), "/abs/x.json");
+});
+
+test("normalizeRepoPath rewrites backslashes to forward slashes and coerces to string", () => {
+  assert.equal(normalizeRepoPath("a\\b\\c"), "a/b/c");
+  assert.equal(normalizeRepoPath("already/posix"), "already/posix");
+  assert.equal(normalizeRepoPath(123), "123");
+});
+
+test("toRepoPath normalizes both backslashes and the platform separator to forward slashes", () => {
+  assert.equal(toRepoPath("a\\b/c"), "a/b/c");
+  assert.equal(toRepoPath(path.join("a", "b", "c")), "a/b/c");
+});
+
+test("posixJoin drops falsy segments before joining", () => {
+  assert.equal(posixJoin("a", "", "b"), "a/b");
+  assert.equal(posixJoin("a", null, undefined, "b"), "a/b");
+  assert.equal(posixJoin(0, "a"), "a");
+});
+
+test("posixJoin collapses runs of slashes into a single separator", () => {
+  assert.equal(posixJoin("a/", "/b"), "a/b");
+  assert.equal(posixJoin("a//b", "c"), "a/b/c");
+});
+
+test("slugForArtifact replaces non-alphanumeric runs with a single dash", () => {
+  assert.equal(slugForArtifact("Hello, World!"), "Hello-World");
+  assert.equal(slugForArtifact("a__b"), "a-b");
+  assert.equal(slugForArtifact(123), "123");
+});
+
+test("slugForArtifact trims leading and trailing dashes", () => {
+  assert.equal(slugForArtifact("  Hello, World!  "), "Hello-World");
+  assert.equal(slugForArtifact("--a__b--"), "a-b");
+  assert.equal(slugForArtifact("!!!"), "");
+});


### PR DESCRIPTION
## What Problem This Solves

`src/path-utils.js` exports six shared path helpers. Existing workspace-plan and profile-diff consumer tests already execute the module, but there is no dedicated `test/path-utils.test.js` on main. These tests add direct branch coverage for labeled required-path errors, relative/absolute paths, separator normalization, falsy path segments, repeated slashes, and artifact slug trimming.

## Why This Change Was Made

Coverage-only: one new file, `test/path-utils.test.js` (+64/-0), with nine tests against the real exported helpers and no stubs or production changes. The assertions protect existing path and artifact contracts without adding configuration, dependencies, report fields, or runtime behavior.

Original contribution by @KrasimirKralev. The contributor's branch and exact head `8e79692ee54c6023c99633c72a380020f22db926` remain unchanged.

## User Impact

No user-visible or runtime change. Maintainers gain focused regression checks for existing path-helper behavior. No changelog, release, downstream pin update, or external runtime integration is needed for this tests-only diff.

## Evidence

### Fresh Maintainer Verification

- September 9, 2026: [secretless Node22 CI run 34366915512](https://github.com/openclaw/plugin-inspector/actions/runs/34366915512) passed on the unchanged contributor head merged with current main `84ede904fd6e766a9fc4de002f39af87d90c1916`.
- All 259 tests passed, including the nine direct path-helper tests; package contents validation passed.
- The job reported `Secret source: None` and read-only Contents/Metadata token permissions. No fork code was executed locally.
- `src/path-utils.js` is byte-identical at the PR base, contributor head, and current main. The merge preview adds only the original 64 test lines.
- Fresh independent P2 review found no actionable defects; `git diff --check` passed.
- Maintainer decision: focused contract tests plus fresh Node22 CI are proportional proof for this strictly test-only change under current policy. ClawSweeper reported no code findings; its requested maintainer decision on test-only proof is resolved. No live API/runtime claim or waiver of enforced GitHub checks/reviews is involved.

The original August 3 CI run could no longer be rerun because it was over a month old. Closing and reopening this same PR triggered the fresh run without editing the contributor branch.

### Original Contributor Evidence

The contributor reported Linux/Node22.22 validation at PR base `392cc7c8d6419965bb351584aaa47a50abd2ebce`: nine focused tests passed, and the then-current full suite increased from 234 to 243 passing tests. These are historical counts, not the fresh current-main totals above.

The contributor also reported mutation controls, restored byte-identically afterward:

| Mutation to `path-utils.js` | Reported Result |
| --- | --- |
| Remove the required-path throw | 1 failure |
| Remove `posixJoin` falsy filtering | 1 failure |
| Remove `posixJoin` slash collapsing | 1 failure |
| Remove artifact-slug dash trimming | 2 failures |
| Remove backslash normalization | 2 failures |
| Restored control | 9 passing tests |

The mutation controls are contributor-reported historical evidence, not local maintainer execution.
