### PR TITLE
fix: read raw packed plugin manifest fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Preserve record predicate and coercion contracts in generated SDK mocks so schema-aware plugin imports cannot recurse through primitive values.
+- Read raw plugin manifest fields from packed OpenClaw declarations instead of runtime registry fields, avoiding false unknown-field warnings for supported metadata such as `uiHints`.
 
 ## 0.3.20 - 2026-07-31
 

--- a/src/openclaw-target.js
+++ b/src/openclaw-target.js
@@ -284,12 +284,12 @@ async function readPackedOpenClawTargetSurface({ rootDir, requestedPaths, reques
     }))
     .sort((left, right) => right.values.length - left.values.length)[0];
   const hookDeclaration = declarations.find((declaration) => declaration.source.includes("type PluginHookName ="));
-  const manifestDeclaration = declarations.find((declaration) => declaration.source.includes("type PluginManifestRecord ="));
+  const manifestDeclaration = declarations.find((declaration) => declaration.source.includes("type PluginManifest ="));
   const manifestContractDeclaration = declarations.find((declaration) => declaration.source.includes("type PluginManifestContracts ="));
   const apiRegistrars = apiDeclaration?.values ?? [];
   const hookNames = hookDeclaration ? parseStringUnion(hookDeclaration.source, "PluginHookName") : [];
   const manifestFields = manifestDeclaration
-    ? parseObjectTypeFields(manifestDeclaration.source, "PluginManifestRecord")
+    ? parseObjectTypeFields(manifestDeclaration.source, "PluginManifest")
     : [];
   const manifestContractFields = manifestContractDeclaration
     ? parseObjectTypeFields(manifestContractDeclaration.source, "PluginManifestContracts")

--- a/test/openclaw-target.test.js
+++ b/test/openclaw-target.test.js
@@ -175,6 +175,44 @@ export type PluginManifestContracts = {
   assert.deepEqual(target.manifestContractFields, ["channels", "tools"]);
 });
 
+test("packed OpenClaw target parser reads raw manifest fields", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-openclaw-target-"));
+  t.after(() => rm(rootDir, { recursive: true, force: true }));
+
+  const targetRoot = path.join(rootDir, "openclaw");
+  await mkdir(path.join(targetRoot, "dist"), { recursive: true });
+  await writeFile(
+    path.join(targetRoot, "package.json"),
+    JSON.stringify({ name: "openclaw", version: "2026.7.2-beta.7" }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(targetRoot, "dist", "manifest.d.ts"),
+    `type PluginManifest = {
+  id: string;
+  configSchema: Record<string, unknown>;
+  uiHints?: Record<string, unknown>;
+  contracts?: PluginManifestContracts;
+};
+type PluginManifestContracts = {
+  tools?: string[];
+};
+type PluginManifestRecord = {
+  id: string;
+  configUiHints?: Record<string, unknown>;
+  rootDir: string;
+};\n`,
+    "utf8",
+  );
+
+  const target = await readOpenClawTargetSurface({ rootDir, configuredPath: "./openclaw" });
+
+  assert.equal(target.version, "2026.7.2-beta.7");
+  assert.equal(target.manifestTypesPath, "openclaw/dist/manifest.d.ts");
+  assert.deepEqual(target.manifestFields, ["configSchema", "contracts", "id", "uiHints"]);
+  assert.deepEqual(target.manifestContractFields, ["tools"]);
+});
+
 test("OpenClaw target parser reports disabled and missing targets", async () => {
   assert.equal((await readOpenClawTargetSurface({ configuredPath: false })).status, "disabled");
 


### PR DESCRIPTION
## Summary

- Read raw `PluginManifest` fields from packed OpenClaw declarations.
- Add regression coverage distinguishing raw `uiHints` from runtime `configUiHints`.

## Proof

- New regression fails on `origin/main`: actual fields are `configUiHints`, `id`, `rootDir`; expected raw fields include `configSchema`, `contracts`, `id`, `uiHints`.
- Same regression passes on this branch.
- Composio exact-version validation changes from 1 warning to 0 warnings.
- `npm run release:contents` and `git diff --check` pass.

`npm test` passes 235/236; the remaining TypeScript import-classification failure reproduces on clean `origin/main` under Node 26.
