### PR TITLE
chore(release): prepare plugin-inspector 0.3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.21 - 2026-08-05
+
 ### Fixed
 
 - Preserve record predicate and coercion contracts in generated SDK mocks so schema-aware plugin imports cannot recurse through primitive values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/plugin-inspector",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "private": false,
   "description": "Offline compatibility inspector for OpenClaw plugins.",
   "type": "module",


### PR DESCRIPTION
## Summary

- release `@openclaw/plugin-inspector@0.3.21`
- move the two post-`0.3.20` fixes into dated release notes

## Validation

- `npm ci`
- `npm run release:local` (236 tests; 59 packed entries)
- exact-head CI and CodeQL: PASS
- trusted release workflow: PASS
- npm registry readback: `0.3.21`, integrity `sha512-EKrsUSI+cYNMi90XECHNbvJ7HrlBS8XXcXFMaw3c64ZVCAVC93dF6f9OgOJ7Mli8XzTnN5vOEhg+K/gKC5l6fg==`
- Crabpot published follow-through checklist: PASS
- Crabpot source and package modes exercised all 60 fixtures; both matched the previous Inspector baseline exactly (26 pre-existing corpus expectation failures, normalized hash `be64a9dbe306cb7012c6d612fa473e6772dafd2c7e53b72f332fb3d00f7d0006`)

## Follow-through

- Release: https://github.com/openclaw/plugin-inspector/releases/tag/v0.3.21
- Crabpot pin: https://github.com/openclaw/crabpot/pull/283
- ClawHub pin: https://github.com/openclaw/clawhub/pull/3413