### PR TITLE
chore(deps): refresh CI tooling and SARIF upload action

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.1.2"
+  PNPM_VERSION: "11.24.0"
 
 jobs:
   hydrate:
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Refresh Crabbox hydration tooling to pnpm 11.24.0 and pnpm/action-setup 6.0.10.
+- Update the code-scanning example to CodeQL's Node 24-based SARIF upload action.
+
 ## 0.3.21 - 2026-08-05
 
 ### Fixed

--- a/examples/github-actions-code-scanning.yml
+++ b/examples/github-actions-code-scanning.yml
@@ -20,7 +20,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: reports/plugin-inspector.sarif


### PR DESCRIPTION
Refresh the remaining pinned CI tooling without changing the package runtime, dependency graph, or version.

Updates:

- Crabbox hydration: pnpm 11.1.2 → 11.24.0; pnpm/action-setup 6.0.9 → 6.0.10.
- Code-scanning example: github/codeql-action/upload-sarif v3 → v4. The SARIF input is unchanged, and the example already runs on ubuntu-latest with Node 24.
- Add matching Unreleased changelog entries.

The npm registry confirms semver 7.8.5, tar 7.5.22, and all five transitive packages are current. A lockfile refresh produced no changes. Other Actions references already track the latest stable major or exact release. No upgrades were held, and no open Dependabot/Renovate PRs are superseded.

Validation:

- npm ci: seven packages installed, zero audit vulnerabilities.
- npm run check: 236 tests passed, zero failed/skipped, plus the package-contents guard on Node 22.23.2, 24.20.0, and 26.7.0.
- actionlint: all five repository workflows and both GitHub Actions examples passed.
- Isolated pnpm 11.24.0 installation/version check passed.
- Packed CLI installation and offline sample-plugin CI smoke passed with runtime SDK mocks: zero breakages and nine report files, including SARIF and JUnit.
- Autoreview found no actionable blocking findings; git diff --check passed.

Baseline Check and ClawSweeper Dispatch runs were green. The latest release run was also green. The old Release Drafter failure from April 27 is a GitHub query execution error according to its retained check annotation; its logs have expired. That workflow has since been made manual-only. This PR does not rerun release/draft creation or claim to clear that historical failure. Crabbox hydration has no recorded main-branch runs and remains a manual workflow; local checks do not prove a live self-hosted hydration run.

No release, package/API behavior change, or Crabpot pin update is involved.
