### PR TITLE
fix: run registration lifecycle probes serially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Run `registerService` start, stop, and dispose probes serially so teardown cannot overlap startup.
+
 - Capture plugins that bind `api.runtime.modelAuth` during registration with credential-free defaults; auth acquisition remains an explicit synthetic failure.
 
 ## 0.3.24 - 2026-08-31

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -784,40 +784,17 @@ async function runRegistrationProbes(entry, retainedEntry, captureIndex, options
     return [blockedResult(entry, captureIndex, "captured registration has no supported callable probe")];
   }
 
-  // Match hook ordering: start, then other callables, then stop/dispose.
-  // Overlapping start with teardown races plugin lifecycle.
-  const results = [];
-  for (const invocation of orderRegistrationInvocations(invocations)) {
-    results.push(
-      await runProbe({
+  return Promise.all(
+    invocations.map((invocation) =>
+      runProbe({
         captureIndex,
         kind: "registration",
         seam: entry.name,
         label: invocation.label,
         invoke: invocation.invoke,
       }),
-    );
-  }
-  return results;
-}
-
-function orderRegistrationInvocations(invocations) {
-  return [...invocations].sort(
-    (left, right) => registrationLifecyclePhase(left.label) - registrationLifecyclePhase(right.label),
+    ),
   );
-}
-
-function registrationLifecyclePhase(label) {
-  if (label.endsWith(".start")) {
-    return 0;
-  }
-  if (label.endsWith(".stop")) {
-    return 2;
-  }
-  if (label.endsWith(".dispose")) {
-    return 3;
-  }
-  return 1;
 }
 
 function registrationInvocations(registrar, descriptor, returnValue, profile, options) {

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -759,17 +759,40 @@ async function runRegistrationProbes(entry, retainedEntry, captureIndex, options
     return [blockedResult(entry, captureIndex, "captured registration has no supported callable probe")];
   }
 
-  return Promise.all(
-    invocations.map((invocation) =>
-      runProbe({
+  // Match hook ordering: start, then other callables, then stop/dispose.
+  // Overlapping start with teardown races plugin lifecycle.
+  const results = [];
+  for (const invocation of orderRegistrationInvocations(invocations)) {
+    results.push(
+      await runProbe({
         captureIndex,
         kind: "registration",
         seam: entry.name,
         label: invocation.label,
         invoke: invocation.invoke,
       }),
-    ),
+    );
+  }
+  return results;
+}
+
+function orderRegistrationInvocations(invocations) {
+  return [...invocations].sort(
+    (left, right) => registrationLifecyclePhase(left.label) - registrationLifecyclePhase(right.label),
   );
+}
+
+function registrationLifecyclePhase(label) {
+  if (label.endsWith(".start")) {
+    return 0;
+  }
+  if (label.endsWith(".stop")) {
+    return 2;
+  }
+  if (label.endsWith(".dispose")) {
+    return 3;
+  }
+  return 1;
 }
 
 function registrationInvocations(registrar, descriptor, returnValue, profile, options) {

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -784,17 +784,20 @@ async function runRegistrationProbes(entry, retainedEntry, captureIndex, options
     return [blockedResult(entry, captureIndex, "captured registration has no supported callable probe")];
   }
 
-  return Promise.all(
-    invocations.map((invocation) =>
-      runProbe({
+  // The profile owns lifecycle order; finish each callback before starting the next.
+  const results = [];
+  for (const invocation of invocations) {
+    results.push(
+      await runProbe({
         captureIndex,
         kind: "registration",
         seam: entry.name,
         label: invocation.label,
         invoke: invocation.invoke,
       }),
-    ),
-  );
+    );
+  }
+  return results;
 }
 
 function registrationInvocations(registrar, descriptor, returnValue, profile, options) {

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -456,8 +456,9 @@ test("synthetic probes finish registerService start before stop and dispose", as
     "      startFinished = true;",
     "      return { started: true };",
     "    },",
-    "    stop() {",
+    "    async stop() {",
     "      if (!startFinished) throw new Error('stop ran before start finished');",
+    "      await new Promise((resolve) => setImmediate(resolve));",
     "      stopFinished = true;",
     "      return { stopped: true };",
     "    },",
@@ -472,7 +473,7 @@ test("synthetic probes finish registerService start before stop and dispose", as
 
   const result = await runCapturedSyntheticProbes(capture, { includeLifecycle: true });
 
-  assert.equal(result.summary.failCount, 0);
+  assert.equal(result.summary.failCount, 0, JSON.stringify(result.results));
   assert.deepEqual(
     result.results.map((item) => `${item.status}:${item.label}`),
     [

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -388,6 +388,45 @@ test("synthetic probes keep opt-in registrations guarded", async () => {
   assert.equal(executed.results[0].label, "registerService.start");
 });
 
+test("synthetic probes finish registerService start before stop and dispose", async () => {
+  const capture = await captureLocalFixture([
+    "let startFinished = false;",
+    "let stopFinished = false;",
+    "export function register(api) {",
+    "  api.registerService({",
+    "    name: 'fixture_service',",
+    "    async start() {",
+    "      await new Promise((resolve) => setImmediate(resolve));",
+    "      startFinished = true;",
+    "      return { started: true };",
+    "    },",
+    "    stop() {",
+    "      if (!startFinished) throw new Error('stop ran before start finished');",
+    "      stopFinished = true;",
+    "      return { stopped: true };",
+    "    },",
+    "    dispose() {",
+    "      if (!startFinished) throw new Error('dispose ran before start finished');",
+    "      if (!stopFinished) throw new Error('dispose ran before stop finished');",
+    "      return { disposed: true };",
+    "    },",
+    "  });",
+    "}",
+  ]);
+
+  const result = await runCapturedSyntheticProbes(capture, { includeLifecycle: true });
+
+  assert.equal(result.summary.failCount, 0);
+  assert.deepEqual(
+    result.results.map((item) => `${item.status}:${item.label}`),
+    [
+      "pass:registerService.start",
+      "pass:registerService.stop",
+      "pass:registerService.dispose",
+    ],
+  );
+});
+
 test("mock SDK capture preserves retained registration metadata across subprocesses", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-mock-sdk-"));
   const entrypoint = path.join(dir, "fixture.mjs");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running synthetic probes with `includeLifecycle` see a registered service's `stop` and `dispose` callbacks run before asynchronous `start` finishes. This can report false failures or tear down partially initialized state.

## Why This Change Was Made

Await the existing registration invocations one at a time in the order owned by `profile.callableProperties`. The service profile already declares `start`, `stop`, then `dispose`; the final repair uses that existing order directly.

Invocation construction, arguments, opt-in guards, failure records, and `captureIndex` grouping are unchanged. Each callback settles before the next begins; recorded failures still allow later cleanup callbacks to run.

Original fix and regression contributed by @SebTardif. The contributor branch and ancestry are preserved, with current main integrated through merge commits. The existing regression now yields during both startup and stop, covering disposal before asynchronous teardown finishes as well.

## User Impact

Service lifecycle probes no longer overlap startup and teardown. This orders callbacks within each captured registration; it does not keep a service running around other registrations or establish a live Gateway lifecycle contract.

No new options, exports, dependencies, or timeout behavior are added.

## Evidence

- Red checkpoint: [Node 22 CI run 34373195617](https://github.com/openclaw/plugin-inspector/actions/runs/34373195617), head `f7d1314d6723002fe0c499d3cb0d01be2e1a5205`. The registration owner was byte-identical to pre-fix main. Of 359 tests, 358 passed and only the service regression failed. Its result records reported `stop ran before start finished` and `dispose ran before start finished`.
- That deliberate red checkpoint was followed by the restored, narrowed repair; it is not the final candidate.
- Green final head: [Node 22 CI run 34373418279](https://github.com/openclaw/plugin-inspector/actions/runs/34373418279), head `04d7e65763c64ddd012092a65451692ee1cb09fe`, integrated with main `7cbdafa1a9c3a107c879088ffed98054cf11db5f`. `npm run check` passed all 359 tests, including the asynchronous service regression and existing opt-in/sibling coverage, plus the package-contents check.
- Both proof runs report `Secret source: None` with read-only contents and metadata permissions.
- Fresh independent P2 review of the final narrowed diff found no actionable findings. `git diff --check` passes.
- The complete final source, test, and changelog diff was reviewed and approved.
- Final scope against integrated main is three files: `src/synthetic-probes.js`, `test/synthetic-probes.test.js`, and one changelog entry. No profile, capture-runtime, process-boundary, or Gateway changes.

The regression exercises the production capture/probe APIs with isolated callbacks. Contributor code was not executed locally, and no AWS lease was created. No live Gateway or hung-callback deadline proof is claimed. Crabpot consumer smoke has not been run in this preparation; that followthrough remains with the consolidated release integration.

Final head `04d7e65763c64ddd012092a65451692ee1cb09fe` is approved and authorized for squash landing, with the documented downstream consumer followthrough retained for release integration.
