### PR TITLE
fix: finish target extraction before cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.22 - 2026-08-30
+
+### Fixed
+
+- Finish OpenClaw target archive extraction before cleanup so strict extraction errors cannot race unfinished filesystem writes.
+
 ### Changed
 
 - Refresh Crabbox hydration tooling to pnpm 11.24.0 and pnpm/action-setup 6.0.10.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/plugin-inspector",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "private": false,
   "description": "Offline compatibility inspector for OpenClaw plugins.",
   "type": "module",

--- a/src/openclaw-version.js
+++ b/src/openclaw-version.js
@@ -149,7 +149,9 @@ async function preparePackageArchive(resolvedTarget, options) {
   try {
     const archivePath = path.join(temporaryDir, "openclaw.tgz");
     await writeFile(archivePath, archive);
-    await extractTar({ cwd: temporaryDir, file: archivePath, strict: true });
+    // Async tar rejection can leave filesystem writes running. Finish extraction
+    // before finally removes its workspace, including when strict validation fails.
+    extractTar({ cwd: temporaryDir, file: archivePath, strict: true, sync: true });
     const packageDir = path.join(temporaryDir, "package");
     if (!(await isPreparedPackage(packageDir, resolvedTarget.version))) {
       throw new Error(`downloaded OpenClaw ${resolvedTarget.version} archive has unexpected package metadata`);

--- a/test/openclaw-version.test.js
+++ b/test/openclaw-version.test.js
@@ -2,10 +2,13 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import fs from "node:fs";
+import fsPromises, { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { c as createTar } from "tar";
+import { c as createTar, Header } from "tar";
+import { gzipSync, gunzipSync } from "node:zlib";
 import { promisify } from "node:util";
 import { test } from "node:test";
 import {
@@ -58,6 +61,53 @@ test("targets without verifiable npm integrity metadata are rejected", async (t)
     () => resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl }),
     /verifiable integrity metadata/,
   );
+});
+
+test("failed target extraction finishes filesystem work before removing its workspace", async (t) => {
+  const fixture = await createRegistryFixture(t, { invalidArchiveHeader: true });
+  const target = await resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl });
+  const pending = new Set();
+  const cleanupPendingCounts = [];
+  let resolveIdle;
+  // Observe real callback-based extraction work, including work queued by a callback.
+  for (const name of ["stat", "mkdir", "lstat", "open", "write", "futimes", "utimes", "fchown", "chown", "close", "unlink", "rmdir"]) {
+    const original = fs[name];
+    t.mock.method(fs, name, (...args) => {
+      const callback = args.pop();
+      const operation = {};
+      pending.add(operation);
+      return original(...args, (...result) => {
+        try {
+          callback(...result);
+        } finally {
+          pending.delete(operation);
+          if (pending.size === 0) resolveIdle?.();
+        }
+      });
+    });
+  }
+  const originalRm = fsPromises.rm;
+  t.mock.method(fsPromises, "rm", async (...args) => {
+    if (path.dirname(args[0]) === path.join(fixture.cacheDir, "openclaw")) {
+      cleanupPendingCounts.push(pending.size);
+      // Drain a regressed extractor before actually deleting the test workspace.
+      if (pending.size > 0) await new Promise((resolve) => { resolveIdle = resolve; });
+    }
+    return originalRm(...args);
+  });
+  syncBuiltinESMExports();
+  t.after(() => {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  });
+
+  await assert.rejects(
+    () => prepareOpenClawTarget(target, { cacheDir: fixture.cacheDir }),
+    (error) => error.tarCode === "TAR_ENTRY_INVALID" && /checksum failure/.test(error.message),
+  );
+  assert.deepEqual(cleanupPendingCounts, [0], "cleanup must not overtake extraction filesystem work");
+  assert.equal(pending.size, 0);
+  assert.deepEqual(await readdir(path.join(fixture.cacheDir, "openclaw")), []);
 });
 
 test("registry-controlled dist-tags cannot escape the target cache", async (t) => {
@@ -299,7 +349,7 @@ async function writeHonchoPlugin(pluginRoot, compatibilityRange) {
   );
 }
 
-async function createRegistryFixture(t) {
+async function createRegistryFixture(t, options = {}) {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-registry-"));
   const cacheDir = path.join(rootDir, "cache");
   const packageRoot = path.join(rootDir, "archive", "package");
@@ -325,7 +375,15 @@ async function createRegistryFixture(t) {
     "utf8",
   );
   await createTar({ cwd: path.join(rootDir, "archive"), file: tarballPath, gzip: true }, ["package"]);
-  const archive = await readFile(tarballPath);
+  let archive = await readFile(tarballPath);
+  if (options.invalidArchiveHeader) {
+    const invalidHeader = new Header({ path: "package/invalid", type: "File", size: 0, mode: 0o644 });
+    invalidHeader.encode();
+    invalidHeader.block[0] ^= 1;
+    // Queue a real directory creation before the strict parser rejects the next entry.
+    archive = gzipSync(Buffer.concat([gunzipSync(archive).subarray(0, 512), invalidHeader.block, Buffer.alloc(1024)]));
+    await writeFile(tarballPath, archive);
+  }
 
   const requests = [];
   const distTags = { latest: "2026.7.1-2", beta: affectedBeta };


### PR DESCRIPTION
ClawHub publication can fail while preparing the current OpenClaw target because asynchronous tar extraction rejects before its pending filesystem writes finish. Cleanup then races those writes and can replace the original error with `ENOTEMPTY`.

Use tar's supported synchronous file extraction at the preparation owner so both success and failure finish filesystem work before cleanup. Integrity verification, strict extraction, package metadata checks, and inspection policy remain unchanged. This prepares patch release 0.3.22; it does not change OpenClaw 2026.8.1 artifacts. The initiating production extraction error remains unproven, so successful backend publication must still be verified after deployment.

Validation: the real invalid-checksum regression observes two pending filesystem operations before the fix and zero afterward; the original error is preserved and the temporary directory is removed. All 237 tests, package-content checks, 60 Crabpot fixtures, all 19 packed exports, and strict preparation of the exact published OpenClaw archive passed. Structured P0 review found no blocker. Executable production LOC is unchanged; two comments explain cleanup ownership.

Captured maintainer proof for `15cf03b7a4cfbe12967df79df5f9fdc2e2b5cabc` (inspector 0.3.22):

The packed candidate's unchanged public `openClawTargets.resolveVersion("2026.8.1")` and `openClawTargets.prepare(...)` flow was run against the live npm registry on 2026-08-31 at 04:03 UTC, using a fresh temporary cache. A fetch observer measured the downloaded bytes without substituting a fixture response. Preparation passed, discovered 57 public registrars, and the second preparation reused the cache. Exactly one archive was downloaded, with SHA256 `43c4b1f81afcd50244c85bcb5686fa6e39f0da6a5941735811b58064b7e0ca10`. The task-owned cache was removed successfully. This is local maintainer evidence, not CI or deployed ClawHub evidence.

The strict-failure proof is a labeled, instrumented regression through the real preparation owner and real tar parser. Its integrity-valid fixture contains a valid directory followed by a checksum-invalid header. It requires the original `TAR_ENTRY_INVALID` / `checksum failure` error, observes callback-based filesystem work at cleanup entry, and verifies an empty cache after rejection. The test drains outstanding callbacks before physically deleting its scratch directory so testing the old implementation does not leave background writes. It does not mock tar or assert its option shape.

```text
node --test --test-name-pattern='failed target extraction' test/openclaw-version.test.js
old source: FAIL — cleanup must not overtake extraction filesystem work
            actual pending filesystem operations: 2; expected: 0
            the original TAR_ENTRY_INVALID assertion had already passed
fixed source: PASS — original strict error retained; pending operations: 0;
              no prepared target or temporary extraction directory remains
```

The retained fixed owner-file run passed all 13 cases; the complete suite passed 237 tests. The canonical Crabpot source smoke passed 60 fixtures with zero breakages. That smoke does not consume an OpenClaw host target; the live preparation above supplies the separate target proof.

This proves the extraction/cleanup ownership repair and successful preparation of the published package. It does not identify the original masked error in ClawHub's deployed environment or claim publication recovery before a live backend attempt.

Crabpot release sequencing: source reference and exact assertion are prepared in commit `2ef9b2cfb7a4ac0ede186fcd98168e17c99bb045`, with the canonical unpublished-source checklist and four focused tests passing. The 60-fixture source smoke is hash-bound to the five files in the reviewed inspector commit. The npm pin and package-mode smoke intentionally follow publication of 0.3.22; they cannot honestly pass before the version exists. This addresses the applicable pre-tag source stage; the package stage remains part of release closeout. No scan, integrity, or strict-extraction check is waived.
