### PR TITLE
fix: bound memory used to mask source comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.23 - 2026-08-30
+
+### Fixed
+
+- Mask source comments in spans so inspecting large bundled JavaScript stays within serverless memory limits while preserving source offsets and findings.
+
 ## 0.3.22 - 2026-08-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/plugin-inspector",
-      "version": "0.3.22",
+      "version": "0.3.23",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "private": false,
   "description": "Offline compatibility inspector for OpenClaw plugins.",
   "type": "module",

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -727,38 +727,11 @@ function lineForOffset(text, offset) {
 }
 
 function stripComments(text) {
-  let result = "";
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    const next = text[index + 1];
-    if (char === "/" && next === "*") {
-      result += "  ";
-      index += 2;
-      while (index < text.length && !(text[index] === "*" && text[index + 1] === "/")) {
-        result += blankCommentChar(text[index]);
-        index += 1;
-      }
-      if (index < text.length) {
-        result += "  ";
-        index += 1;
-      }
-    } else if (char === "/" && next === "/") {
-      result += "  ";
-      index += 2;
-      while (index < text.length && text[index] !== "\n" && text[index] !== "\r") {
-        result += " ";
-        index += 1;
-      }
-      index -= 1;
-    } else {
-      result += char;
-    }
-  }
-  return result;
-}
-
-function blankCommentChar(char) {
-  return char === "\n" || char === "\r" ? char : " ";
+  // Mask spans rather than building one string node per UTF-16 code unit.
+  // Keep offsets and CR/LF intact for findings, including unterminated comments.
+  return text.replace(/\/\*[\s\S]*?(?:\*\/|$)|\/\/[^\r\n]*/g, (comment) =>
+    comment.replace(/[^\r\n]+/g, (span) => " ".repeat(span.length)),
+  );
 }
 
 function sortDetails(details) {

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -128,6 +129,39 @@ test("source inspection strips long comments before matching registrations", () 
     inspection.registrations.map((registration) => `${registration.name}@${registration.ref}`),
     ["registerTool@plugins/example/index.ts:2"],
   );
+});
+
+test("source inspection masks large comments within a bounded heap", () => {
+  const child = spawnSync(process.execPath, [
+    "--max-old-space-size=128",
+    "--input-type=module",
+    "-e",
+    `import { inspectSourceText } from ${JSON.stringify(new URL("../src/inspector.js", import.meta.url).href)};
+     const source = "/*" + "x".repeat(8 * 1024 * 1024) + "*/\\napi.registerTool({});";
+     console.log(JSON.stringify(inspectSourceText(source).registrations));`,
+  ], { encoding: "utf8", timeout: 30_000, env: { ...process.env, NODE_OPTIONS: "" } });
+  assert.equal(child.status, 0, child.stderr);
+  assert.deepEqual(JSON.parse(child.stdout), [
+    { name: "registerTool", file: "source.js", line: 2, ref: "source.js:2" },
+  ]);
+});
+
+test("comment masking preserves source locations and token boundaries", () => {
+  for (const [comment, line] of [
+    ["/* 🦞\ud800 */", 1],
+    ["/* first\r\nsecond\nthird\rlast */", 3],
+    ["// hidden api.registerService({});\r\n", 2],
+    ["/* outer /* nested */", 1],
+    ["/**/", 1],
+  ]) {
+    const inspection = inspectSourceText(`${comment}api.registerTool({});`);
+    assert.deepEqual(inspection.registrations, [
+      { name: "registerTool", file: "source.js", line, ref: `source.js:${line}` },
+    ]);
+  }
+  assert.deepEqual(inspectSourceText("api./* hidden */registerTool({});").registrations, []);
+  assert.deepEqual(inspectSourceText("/* unterminated\r\napi.registerTool({});").registrations, []);
+  assert.deepEqual(inspectSourceText("// unterminated api.registerTool({});").registrations, []);
 });
 
 test("source inspection records deprecated whole-store session helper usage", () => {


### PR DESCRIPTION
Inspecting a 14 MB JavaScript bundle uses about 583 MiB on Node.js 20 because comment masking creates one string node per UTF-16 code unit. This exceeds Convex's documented 512 MiB Node action memory limit and is a concrete resource defect relevant to the remaining ClawHub publication failure. The backend's generic error does not itself prove an OOM.

Mask complete comment spans while retaining every non-comment byte, UTF-16 offset, CR/LF and unterminated-comment behavior. This removes the character concatenation loop and its helper: production code changes by +5/-32 lines. No source files, findings, integrity checks or security policies are skipped or relaxed. This prepares patch release 0.3.23; OpenClaw release artifacts remain unchanged.

Captured static inspection of the exact retained asset on verified Node.js 20.20.2:

```text
asset bytes: 14,006,143
asset SHA-256: d711f760d14db992cdd6c5a1013bf819dc6207b4ce51b8d5d1a820ae8a189855
before peak RSS: 610,828,288 bytes; elapsed: 838 ms
after peak RSS: 134,512,640 bytes; elapsed: 188 ms
inspection output SHA-256 before and after:
8cc61407019ad62d679039b666fe1fc0cbd28ff40c5697da1ca80e9053c567d6
plugin code executed: no
```

The bounded-heap regression fails with the old implementation and passes with this repair. All 239 tests, package-content checks, 19 packed exports and CLI help passed. A separate diagnostic compared 24,549 text cases, including all UTF-16 code units, and preserved the exact masking output. Independent scoped review found no actionable issue. The measured runtime matches Convex's documented default major; its exact deployed patch version is unknown.

Crabpot source-reference and source-smoke follow-through is being completed in https://github.com/openclaw/crabpot/pull/294 before tagging; the package pin and package-mode smoke follow actual npm publication. That PR retains its separately diagnosed fixture/coverage failures rather than weakening their expectations. Backend publication must be checked after deployment; local static proof does not claim deployed recovery.

Runtime contracts: https://docs.convex.dev/functions/runtimes and https://docs.convex.dev/production/state/limits.
