### PR TITLE
chore(deps): refresh Crabbox pnpm to 12.1.0

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.24.0"
+  PNPM_VERSION: "12.1.0"
 
 jobs:
   hydrate:


### PR DESCRIPTION
## What Problem This Solves

Refreshes the pnpm version installed by manual Crabbox hydration from 11.24.0 to 12.1.0. This is the only dependency update found; npm remains the repository package manager.

## Why This Change Was Made

Reviewed the [pnpm 12 migration notes](https://github.com/pnpm/pnpm/releases/tag/v12.0.0) and [12.1 release notes](https://github.com/pnpm/pnpm/releases/tag/v12.1.0), then exercised the existing `pnpm/action-setup@v6.0.10` bundle with the exact new version. No Action migration is necessary for this workflow, whose pnpm use is `pnpm --version`.

The npm registry currently exposes 12.1.0 under `next-12`; GitHub marks it as a stable release. The exact version was installed and verified. No major upgrades were skipped. Runtime dependencies remain semver 7.8.5 and tar 7.5.22; `npm outdated --all --json --prefer-online` returned `{}`, and `npm update --package-lock-only --no-fund --ignore-scripts --prefer-online` left the lockfile unchanged. Existing Action references already resolve to current releases: checkout 7.0.1, setup-node 7.0.0, create-github-app-token 3.2.0, pnpm/action-setup 6.0.10, and release-drafter 7.7.0.

## User Impact

Only the manual hydration tool version changes. The published package, report contracts, package version, and release metadata are unchanged, so no changelog or Crabpot pin update is needed.

## Evidence

Local Node 24.20.0 / npm 11.19.0:

```text
$ npm ci --no-fund
added 7 packages, and audited 8 packages in 32s
found 0 vulnerabilities

$ npm run check
ℹ tests 239
ℹ pass 239
ℹ fail 0
ℹ skipped 0
package contents: pass
package entries: 59

$ actionlint .github/workflows/*.yml
[exit 0; no output]
```

This package ships JavaScript directly and has no compile/build script. Built an actual npm tarball, installed it into an isolated local prefix, and ran the installed CLI on a published plugin and the runtime fixture:

```sh
npm pack --pack-destination reports/deps-refresh-20260830 --json > reports/deps-refresh-20260830/pack.json
npm install --prefix reports/deps-refresh-20260830/install --no-save --package-lock=false --ignore-scripts --no-fund ./reports/deps-refresh-20260830/openclaw-plugin-inspector-0.3.23.tgz
npm pack @openclaw/diagnostics-otel@2026.8.1 --ignore-scripts --pack-destination reports/deps-refresh-20260830 --json > reports/deps-refresh-20260830/plugin-pack.json
mkdir -p reports/deps-refresh-20260830/diagnostics-otel
tar -xzf reports/deps-refresh-20260830/openclaw-diagnostics-otel-2026.8.1.tgz -C reports/deps-refresh-20260830/diagnostics-otel
reports/deps-refresh-20260830/install/node_modules/.bin/plugin-inspector ci --plugin-root reports/deps-refresh-20260830/diagnostics-otel/package --no-openclaw --no-runtime --out reports/deps-refresh-20260830/real-plugin-output
```

```text
Status: PASS
Breakages: 0
Issues: 2
Artifacts: 1
```

The real-plugin findings are nonblocking dependency-install and runtime-capture coverage notices. No plugin code was executed in that static check.

```sh
reports/deps-refresh-20260830/install/node_modules/.bin/plugin-inspector ci --plugin-root test/fixtures/sample-plugin --no-openclaw --runtime --mock-sdk --allow-execute --out reports/deps-refresh-20260830/sample-output
```

```text
Status: PASS
Breakages: 0
Issues: 3
Artifacts: 1
```

<details>
<summary>Exact setup Action proof</summary>

```sh
curl -fL --max-time 60 -sS https://raw.githubusercontent.com/pnpm/action-setup/v6.0.10/dist/index.js -o reports/deps-refresh-20260830/pnpm-action.cjs
touch reports/deps-refresh-20260830/github-path reports/deps-refresh-20260830/github-env reports/deps-refresh-20260830/github-output reports/deps-refresh-20260830/github-state
env INPUT_VERSION=12.1.0 INPUT_DEST="$PWD/reports/deps-refresh-20260830/action-install" INPUT_RUN_INSTALL=null INPUT_CACHE=false INPUT_CACHE_DEPENDENCY_PATH=pnpm-lock.yaml INPUT_PACKAGE_JSON_FILE=package.json INPUT_STANDALONE=false GITHUB_WORKSPACE="$PWD" GITHUB_PATH="$PWD/reports/deps-refresh-20260830/github-path" GITHUB_ENV="$PWD/reports/deps-refresh-20260830/github-env" GITHUB_OUTPUT="$PWD/reports/deps-refresh-20260830/github-output" GITHUB_STATE="$PWD/reports/deps-refresh-20260830/github-state" node reports/deps-refresh-20260830/pnpm-action.cjs > reports/deps-refresh-20260830/action-setup.log 2>&1
reports/deps-refresh-20260830/action-install/node_modules/.bin/bin/pnpm --version
```

```text
Switching pnpm from v11.19.0 to v12.1.0...
Successfully updated pnpm to v12.1.0
Installation Completed!
12.1.0
```

The Action emitted a legacy-layout warning during bootstrap; it explicitly adds `PNPM_HOME/bin` to PATH and the resulting binary reports the requested version. No global installation was changed.

</details>

Codex autoreview: scoped-clean, with no accepted/actionable findings at the default P0 threshold.

## CI Reasoning

Default-branch build/test CI was already green: [Check on main](https://github.com/openclaw/plugin-inspector/actions/runs/33358784707). No failing assertion or job was changed. The PR `Check` workflow runs the full suite and package-content guard on Node 22. Crabbox Hydrate, Release, and Release Drafter are manual/tag operations; ClawSweeper Dispatch is event-driven maintenance automation, not build/test CI. The exact setup Action was tested locally; a full remote Crabbox lease/hydration was not dispatched.

PR validation is green: [Check / Node 22](https://github.com/openclaw/plugin-inspector/actions/runs/33373839292) completed successfully at `ff15c6686d80bf632e31e0cb48a04374299279e7`. [ClawSweeper Dispatch](https://github.com/openclaw/plugin-inspector/actions/runs/33373839259) also passed. No CI retries or fixes were needed.
