### PR TITLE
fix: avoid false failures for compiled channels and widget presenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Recognize compiled CommonJS plugin factory calls when checking expected channel registrations, preserving source references and excluding factory values passed to wrappers.
+- Classify widget presenters as metadata-only synthetic probes without invoking presentation callbacks.
+
 ## 0.3.23 - 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ plugin-inspector --help
 
 ## Runtime Capture
 
+Static inspection recognizes direct plugin factory calls and compiled CommonJS
+calls such as `(0, sdk.defineBundledChannelEntry)(...)` without importing them.
 Runtime capture imports plugin entrypoints in an isolated subprocess and records
 what `register(api)` does. Use it when static inspection cannot prove the actual
 registrations made at runtime.
@@ -229,6 +231,10 @@ subpaths and unresolved external packages discovered in the plugin import graph.
 That keeps compatibility CI offline and credential-free. It does not call live
 services, launch OpenClaw, run provider SDKs, or emulate service lifecycle side
 effects.
+
+Synthetic probes classify widget presenters as metadata-only. They record the
+registration without calling its match, availability, or presentation callbacks,
+including when channel, provider, or lifecycle execution is enabled.
 
 Use `--real-sdk` only when the plugin workspace already has real SDK
 dependencies installed and you intentionally want that path.

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -15,6 +15,9 @@ import { buildCompatibilityReport, buildReport } from "./report.js";
 import { inspectSdkDeprecations } from "./sdk-deprecation-rules.js";
 
 const execFileAsync = promisify(execFile);
+const pluginFactoryNames = "defineBundledChannelEntry|defineChannelPluginEntry|createChatChannelPlugin|definePluginEntry";
+// Bundlers emit unbound calls as (0, sdk.factory)(...), including inline require receivers.
+const compiledFactoryCall = new RegExp(String.raw`\(\s*0\s*,\s*(?:require\s*\(\s*(?:"[^"\r\n]*"|'[^'\r\n]*')\s*\)|[$A-Z_a-z][$\w]*)(?:\s*\.\s*[$A-Z_a-z][$\w]*)*\s*\.\s*(${pluginFactoryNames})\s*\)\s*\(`, "dg");
 const registrationEquivalents = new Map([
   ["registerChannel", new Set(["createChatChannelPlugin", "defineBundledChannelEntry", "defineChannelPluginEntry", "registerChannel"])],
 ]);
@@ -164,10 +167,8 @@ export function inspectSourceText(text, filePath = "source.js") {
   const hooks = collectDetailedMatches(searchableText, /\bapi\.on\(\s*["'`]([^"'`]+)["'`]/g, filePath, "name");
   const registrations = [
     ...collectDetailedMatches(searchableText, /\bapi\.(register[A-Za-z0-9]+)\s*\(/g, filePath, "name"),
-    ...collectDetailedMatches(searchableText, /\b(defineBundledChannelEntry)\s*\(/g, filePath, "name"),
-    ...collectDetailedMatches(searchableText, /\b(defineChannelPluginEntry)\s*\(/g, filePath, "name"),
-    ...collectDetailedMatches(searchableText, /\b(createChatChannelPlugin)\s*\(/g, filePath, "name"),
-    ...collectDetailedMatches(searchableText, /\b(definePluginEntry)\s*\(/g, filePath, "name"),
+    ...collectDetailedMatches(searchableText, new RegExp(String.raw`\b(${pluginFactoryNames})\s*\(`, "g"), filePath, "name"),
+    ...collectDetailedMatches(searchableText, compiledFactoryCall, filePath, "name"),
   ];
   const sdkImports = collectSdkImports(searchableText, filePath);
   const sdkDeprecations = inspectSdkDeprecations(searchableText, filePath);
@@ -373,7 +374,7 @@ function emptyInspection(fixture, status) {
 function collectDetailedMatches(text, regex, filePath, key) {
   const details = [];
   for (const match of text.matchAll(regex)) {
-    const line = lineForOffset(text, match.index ?? 0);
+    const line = lineForOffset(text, match.indices?.[1]?.[0] ?? match.index ?? 0);
     details.push({
       [key]: match[1],
       file: filePath,

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -295,6 +295,11 @@ export const syntheticRegistrationExecutionProfiles = {
     callableProperties: [],
     reason: "web search providers are captured as registration metadata before provider runtime execution",
   },
+  registerWidgetPresenter: {
+    mode: "metadata-only",
+    callableProperties: [],
+    reason: "widget presenters are captured as registration metadata before presentation runtime execution",
+  },
 };
 
 export const defaultSyntheticHookEvents = {

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -37,6 +37,33 @@ test("source inspection records hooks and registrars without treating type-only 
   assert.deepEqual(inspection.sdkImports, []);
 });
 
+test("source inspection recognizes direct and compiled plugin factory calls", () => {
+  for (const factory of ["defineBundledChannelEntry", "defineChannelPluginEntry", "createChatChannelPlugin", "definePluginEntry"]) {
+    for (const expression of [
+      `${factory}({});`,
+      `sdk.${factory}({});`,
+      `(0, sdk.${factory})({});`,
+      `(0, sdk.channel.${factory})({});`,
+      `(0, require("openclaw/plugin-sdk/channel-entry-contract").${factory})({});`,
+      `(0,\n require('openclaw/plugin-sdk/channel-entry-contract').${factory} /* compiled */\n) ({});`,
+    ]) {
+      const text = `// ignored ${factory}({});\n${expression}`;
+      const line = text.slice(0, text.lastIndexOf(factory)).split("\n").length;
+      assert.deepEqual(inspectSourceText(text, "index.cjs").registrations, [
+        { name: factory, file: "index.cjs", line, ref: `index.cjs:${line}` },
+      ], expression);
+    }
+    for (const expression of [
+      `(0, sdk.${factory});`,
+      `wrap(sdk.${factory})({});`,
+      `(0, sdk.${factory}Other)({});`,
+      `/* (0, sdk.${factory})({}); */`,
+    ]) {
+      assert.deepEqual(inspectSourceText(expression).registrations, [], expression);
+    }
+  }
+});
+
 test("source inspection ignores all type-only OpenClaw SDK import forms", () => {
   const inspection = inspectSourceText(
     [
@@ -466,6 +493,22 @@ test("fixture set inspection treats channel factories as channel registration co
   assert.equal(report.status, "pass");
   assert.deepEqual(report.breakages, []);
   assert.deepEqual(report.fixtures[0].registrations, ["createChatChannelPlugin", "defineBundledChannelEntry"]);
+
+  await writeFile(path.join(dir, "fixture", "index.js"), "", "utf8");
+  await writeFile(
+    path.join(dir, "fixture", "index.cjs"),
+    'module.exports = (0, require("openclaw/plugin-sdk/channel-entry-contract").defineBundledChannelEntry)({ id: "fixture-channel" });',
+    "utf8",
+  );
+  const compiledReport = await inspectFixtureSet({
+    version: 1,
+    submoduleRoot: ".",
+    rootDir: dir,
+    fixtures: [{ id: "fixture", path: "fixture", expect: { registrations: ["registerChannel"] } }],
+  });
+  assert.equal(compiledReport.status, "pass");
+  assert.deepEqual(compiledReport.breakages, []);
+  assert.deepEqual(compiledReport.fixtures[0].registrations, ["defineBundledChannelEntry"]);
 });
 
 test("capture entrypoint imports a local fixture and records registrations", async () => {

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import {
   buildSyntheticProbePlan,
   captureEntrypoint,
+  createCaptureApi,
   defaultSyntheticHookContexts,
   defaultSyntheticHookEvents,
   renderSyntheticProbeMarkdown,
@@ -166,6 +167,7 @@ test("synthetic probe plan classifies generated kitchen-sink registrars", () => 
     "registerVideoGenerationProvider",
     "registerWebFetchProvider",
     "registerWebSearchProvider",
+    "registerWidgetPresenter",
   ];
   const plan = buildSyntheticProbePlan({
     capture: {
@@ -190,6 +192,39 @@ test("synthetic probe plan classifies generated kitchen-sink registrars", () => 
   assert.equal(plan.summary.probeCount, kitchenSinkRegistrars.length);
   assert.equal(plan.summary.blockedCount, 0);
   assert.deepEqual(validateSyntheticProbePlan(plan), []);
+});
+
+test("synthetic probes capture widget presenters without invoking runtime callbacks", async () => {
+  const api = createCaptureApi({ retainHandlers: true });
+  const invoked = [];
+  const callback = (name) => () => { invoked.push(name); };
+  for (const target of ["current_channel", "node_panel"]) {
+    api.registerWidgetPresenter({
+      target,
+      description: `Fixture ${target}`,
+      availability: callback(`${target}.availability`),
+      present: callback(`${target}.present`),
+      ...(target === "current_channel"
+        ? { match: callback(`${target}.match`), capabilities: { sourceKinds: ["html"] } }
+        : {}),
+    });
+  }
+  const capture = {
+    status: "captured",
+    captured: api.getCapturedContracts(),
+    retained: api.getRetainedContracts(),
+  };
+
+  for (const options of [{}, { includeLifecycle: true, includeChannelRuntime: true, includeProviderCapabilities: true }]) {
+    const result = await runCapturedSyntheticProbes(capture, options);
+
+    assert.deepEqual(result.summary, { probeCount: 2, passCount: 2, failCount: 0, blockedCount: 0 });
+    assert.deepEqual(
+      result.results.map((item) => [item.seam, item.output.mode]),
+      [["registerWidgetPresenter", "metadata-only"], ["registerWidgetPresenter", "metadata-only"]],
+    );
+    assert.deepEqual(invoked, []);
+  }
 });
 
 test("default hook payloads cover message and agent lifecycle readers", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes false compatibility failures when a published plugin uses a compiled CommonJS channel factory call, and blocked synthetic plans when a plugin registers a widget presenter. The published `@openclaw/msteams@2026.8.1` archive contains a valid channel entry but was reported as missing `registerChannel`.

## Why This Change Was Made

The static scanner now recognizes the compiled `(0, receiver.factory)(...)` form alongside direct calls, with source references on the factory name. The shared synthetic profile classifies widget presenters as metadata-only, so the planner and executor agree without invoking callbacks that can send messages or operate devices. Unknown registrars still block; existing opt-in boundaries remain unchanged.

## User Impact

Compiled plugin entrypoints no longer produce a false missing-channel finding. Widget registration metadata can be inspected without executing presentation callbacks. No runtime dependency, config option, or package version change is included; npm consumers need a subsequent authorized release.

## Evidence

- New factory regressions failed on the unchanged base; the exact published Teams 2026.8.1 archive failed with a missing expected channel seam. Both pass after this repair. Archive SHA-256: `a01015b031bf22c75667924ad099e8e6913f8e6e5b79e645daa1249946303d8f`.
- Widget planner/executor regressions failed before the profile existed. Both presenter targets now pass as metadata-only, with zero callback invocations under default settings and all existing execution opt-ins.
- `npm run check`: 241 tests passed and package-content checks passed. Coverage includes direct calls, compiled namespace and inline-require calls, multiline source locations, comments, unrelated wrappers, and unclassified registrars.
- Canonical Crabpot source-mode smoke passed against the retained controlled 60-fixture snapshot: 60 fixtures, zero breakages. This is static fixture evidence, not a claim about current live host behavior or every latest fixture version.
- Scoped autoreview: no blocking findings. Production delta is +6 lines; repeated direct matcher patterns were consolidated.

Crabpot source follow-through is prepared in https://github.com/openclaw/crabpot/pull/294. Its package pin remains 0.3.23 until publication is authorized.
