### PR TITLE
chore: prepare plugin-inspector 0.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.24 - 2026-08-31
+
 ### Fixed
 
 - Recognize compiled CommonJS plugin factory calls when checking expected channel registrations, preserving source references and excluding factory values passed to wrappers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/plugin-inspector",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "private": false,
   "description": "Offline compatibility inspector for OpenClaw plugins.",
   "type": "module",


### PR DESCRIPTION
Prepare plugin-inspector 0.3.24 with the compiled CommonJS factory recognition and metadata-only widget-presenter fixes already merged in #66. Package metadata and lockfile agree, and the release notes come from the reviewed Unreleased section.

Validation: `npm run release:local` passed all 241 tests and package-content checks. The exact local tarball installs in isolation; all 59 package files match this candidate. The corrected Crabpot smoke wrapper passed 60 controlled fixtures in both source and packed-candidate modes with `--check`, and the packed CLI passed against the exact published Teams 2026.8.1 archive. Scoped metadata autoreview found no blocking issue.

This change does not publish npm or create a release tag. Crabpot's package pin stays at 0.3.23 until separately authorized publication and registry verification. Source follow-through is tracked in https://github.com/openclaw/crabpot/pull/294.
