### PR TITLE
fix: abort hung OpenClaw target version fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Abort hung OpenClaw npm metadata and tarball fetches and reject oversized archives before buffering them.
+- Bound OpenClaw npm metadata and tarball downloads with a deadline through response-body reads, reject oversized responses, and release failed downloads. Resolve `latest` and `beta` through the small npm dist-tags endpoint before fetching exact-version metadata, keeping the 16 MiB metadata limit usable.
 
 - Capture plugins that bind `api.runtime.modelAuth` during registration with credential-free defaults; auth acquisition remains an explicit synthetic failure.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Abort hung OpenClaw npm metadata and tarball fetches and reject oversized archives before buffering them.
+
 - Capture plugins that bind `api.runtime.modelAuth` during registration with credential-free defaults; auth acquisition remains an explicit synthetic failure.
 
 ## 0.3.24 - 2026-08-31

--- a/src/openclaw-version.js
+++ b/src/openclaw-version.js
@@ -8,6 +8,9 @@ import { x as extractTar } from "tar";
 import { readOpenClawTargetSurface } from "./openclaw-target.js";
 
 const defaultRegistryUrl = "https://registry.npmjs.org";
+const defaultFetchTimeoutMs = 30_000;
+const defaultMaxArchiveBytes = 256 * 1024 * 1024;
+const defaultMaxMetadataBytes = 16 * 1024 * 1024;
 const supportedTags = new Set(["latest", "beta"]);
 const downloadUrls = new WeakMap();
 
@@ -25,7 +28,7 @@ export async function resolveOpenClawTargetVersion(requestedVersion, options = {
   let distTag = null;
 
   if (supportedTags.has(requested)) {
-    const metadata = await fetchJson(`${registryUrl}/openclaw`, fetchImpl);
+    const metadata = await fetchJson(`${registryUrl}/openclaw`, fetchImpl, options);
     version = metadata["dist-tags"]?.[requested];
     if (typeof version !== "string" || version.length === 0) {
       throw new Error(`OpenClaw npm dist-tag ${requested} did not resolve to an exact version`);
@@ -38,7 +41,7 @@ export async function resolveOpenClawTargetVersion(requestedVersion, options = {
     throw new Error("--openclaw-version must be latest, beta, or an exact OpenClaw version");
   }
 
-  const versionMetadata = await fetchJson(`${registryUrl}/openclaw/${encodeURIComponent(version)}`, fetchImpl);
+  const versionMetadata = await fetchJson(`${registryUrl}/openclaw/${encodeURIComponent(version)}`, fetchImpl, options);
   if (versionMetadata.version !== version || typeof versionMetadata.dist?.tarball !== "string") {
     throw new Error(`OpenClaw npm metadata for ${version} is incomplete`);
   }
@@ -137,11 +140,11 @@ export function satisfiesOpenClawCompatibilityRange({ targetVersion, eligibility
 
 async function preparePackageArchive(resolvedTarget, options) {
   const fetchImpl = options.fetch ?? globalThis.fetch;
-  const response = await fetchImpl(downloadUrlFor(resolvedTarget));
+  const response = await fetchWithTimeout(fetchImpl, downloadUrlFor(resolvedTarget), {}, options, "npm archive");
   if (!response.ok) {
     throw new Error(`failed to download OpenClaw ${resolvedTarget.version}: HTTP ${response.status}`);
   }
-  const archive = Buffer.from(await response.arrayBuffer());
+  const archive = await readLimitedBody(response, maxArchiveBytes(options), "npm archive");
   verifyArchive(archive, resolvedTarget.source);
 
   await mkdir(path.dirname(options.targetDir), { recursive: true });
@@ -191,10 +194,103 @@ function verifyArchive(archive, source) {
   throw new Error("OpenClaw npm archive has no supported integrity metadata");
 }
 
-async function fetchJson(url, fetchImpl) {
-  const response = await fetchImpl(url, { headers: { accept: "application/json" } });
+async function fetchJson(url, fetchImpl, options = {}) {
+  const response = await fetchWithTimeout(
+    fetchImpl,
+    url,
+    { headers: { accept: "application/json" } },
+    options,
+    "npm metadata",
+  );
   if (!response.ok) throw new Error(`failed to resolve OpenClaw npm metadata: HTTP ${response.status}`);
-  return response.json();
+  const body = await readLimitedBody(response, maxMetadataBytes(options), "npm metadata");
+  return JSON.parse(body.toString("utf8"));
+}
+
+async function fetchWithTimeout(fetchImpl, url, init, options, what) {
+  try {
+    return await fetchImpl(url, { ...init, signal: AbortSignal.timeout(fetchTimeoutMs(options)) });
+  } catch (error) {
+    throw mapTargetFetchError(error, what);
+  }
+}
+
+async function readLimitedBody(response, maxBytes, what) {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    try {
+      await response.body?.cancel?.();
+    } catch {}
+    throw targetDownloadLimitError(what, maxBytes);
+  }
+
+  try {
+    if (!response.body || typeof response.body.getReader !== "function") {
+      const buffer = Buffer.from(await response.arrayBuffer());
+      if (buffer.length > maxBytes) throw targetDownloadLimitError(what, maxBytes);
+      return buffer;
+    }
+
+    const reader = response.body.getReader();
+    const chunks = [];
+    let received = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {}
+        throw targetDownloadLimitError(what, maxBytes);
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  } catch (error) {
+    throw mapTargetFetchError(error, what);
+  }
+}
+
+function fetchTimeoutMs(options) {
+  return positiveInteger(options.fetchTimeoutMs ?? process.env.PLUGIN_INSPECTOR_TARGET_FETCH_TIMEOUT_MS, defaultFetchTimeoutMs);
+}
+
+function maxArchiveBytes(options) {
+  return positiveInteger(options.maxArchiveBytes ?? process.env.PLUGIN_INSPECTOR_TARGET_ARCHIVE_MAX_BYTES, defaultMaxArchiveBytes);
+}
+
+function maxMetadataBytes(options) {
+  return positiveInteger(options.maxMetadataBytes ?? process.env.PLUGIN_INSPECTOR_TARGET_METADATA_MAX_BYTES, defaultMaxMetadataBytes);
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function mapTargetFetchError(error, what) {
+  if (error?.failureClass) return error;
+  if (isTimeoutError(error)) {
+    const wrapped = new Error(`OpenClaw ${what} download timed out`);
+    wrapped.failureClass = "target-download-timeout";
+    wrapped.cause = error;
+    return wrapped;
+  }
+  return error;
+}
+
+function isTimeoutError(error) {
+  for (let current = error; current; current = current.cause) {
+    if (current.name === "TimeoutError" || current.name === "AbortError") return true;
+  }
+  return false;
+}
+
+function targetDownloadLimitError(what, maxBytes) {
+  const error = new Error(`OpenClaw ${what} exceeds the ${maxBytes} byte download limit`);
+  error.failureClass = "target-download-too-large";
+  return error;
 }
 
 function cacheKeyFor(target) {

--- a/src/openclaw-version.js
+++ b/src/openclaw-version.js
@@ -28,8 +28,8 @@ export async function resolveOpenClawTargetVersion(requestedVersion, options = {
   let distTag = null;
 
   if (supportedTags.has(requested)) {
-    const metadata = await fetchJson(`${registryUrl}/openclaw`, fetchImpl, options);
-    version = metadata["dist-tags"]?.[requested];
+    const distTags = await fetchJson(`${registryUrl}/-/package/openclaw/dist-tags`, fetchImpl, options);
+    version = distTags?.[requested];
     if (typeof version !== "string" || version.length === 0) {
       throw new Error(`OpenClaw npm dist-tag ${requested} did not resolve to an exact version`);
     }
@@ -142,6 +142,7 @@ async function preparePackageArchive(resolvedTarget, options) {
   const fetchImpl = options.fetch ?? globalThis.fetch;
   const response = await fetchWithTimeout(fetchImpl, downloadUrlFor(resolvedTarget), {}, options, "npm archive");
   if (!response.ok) {
+    await cancelBody(response.body);
     throw new Error(`failed to download OpenClaw ${resolvedTarget.version}: HTTP ${response.status}`);
   }
   const archive = await readLimitedBody(response, maxArchiveBytes(options), "npm archive");
@@ -202,7 +203,10 @@ async function fetchJson(url, fetchImpl, options = {}) {
     options,
     "npm metadata",
   );
-  if (!response.ok) throw new Error(`failed to resolve OpenClaw npm metadata: HTTP ${response.status}`);
+  if (!response.ok) {
+    await cancelBody(response.body);
+    throw new Error(`failed to resolve OpenClaw npm metadata: HTTP ${response.status}`);
+  }
   const body = await readLimitedBody(response, maxMetadataBytes(options), "npm metadata");
   return JSON.parse(body.toString("utf8"));
 }
@@ -218,12 +222,11 @@ async function fetchWithTimeout(fetchImpl, url, init, options, what) {
 async function readLimitedBody(response, maxBytes, what) {
   const declared = Number(response.headers.get("content-length"));
   if (Number.isFinite(declared) && declared > maxBytes) {
-    try {
-      await response.body?.cancel?.();
-    } catch {}
+    await cancelBody(response.body);
     throw targetDownloadLimitError(what, maxBytes);
   }
 
+  let reader;
   try {
     if (!response.body || typeof response.body.getReader !== "function") {
       const buffer = Buffer.from(await response.arrayBuffer());
@@ -231,7 +234,7 @@ async function readLimitedBody(response, maxBytes, what) {
       return buffer;
     }
 
-    const reader = response.body.getReader();
+    reader = response.body.getReader();
     const chunks = [];
     let received = 0;
     while (true) {
@@ -249,11 +252,24 @@ async function readLimitedBody(response, maxBytes, what) {
     return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
   } catch (error) {
     throw mapTargetFetchError(error, what);
+  } finally {
+    reader?.releaseLock();
   }
 }
 
+async function cancelBody(body) {
+  try {
+    await body?.cancel?.();
+  } catch {}
+}
+
 function fetchTimeoutMs(options) {
-  return positiveInteger(options.fetchTimeoutMs ?? process.env.PLUGIN_INSPECTOR_TARGET_FETCH_TIMEOUT_MS, defaultFetchTimeoutMs);
+  const timeout = positiveInteger(
+    options.fetchTimeoutMs ?? process.env.PLUGIN_INSPECTOR_TARGET_FETCH_TIMEOUT_MS,
+    defaultFetchTimeoutMs,
+  );
+  // Node clamps overflowing timer delays to 1ms instead of honoring the budget.
+  return timeout <= 2_147_483_647 ? timeout : defaultFetchTimeoutMs;
 }
 
 function maxArchiveBytes(options) {

--- a/test/openclaw-version.test.js
+++ b/test/openclaw-version.test.js
@@ -76,6 +76,18 @@ test("targets without verifiable npm integrity metadata are rejected", async (t)
   );
 });
 
+test("an archive integrity mismatch leaves no prepared target", async (t) => {
+  const fixture = await createRegistryFixture(t);
+  fixture.distMetadata.integrity = `sha512-${Buffer.alloc(64).toString("base64")}`;
+  const target = await resolveOpenClawTargetVersion(affectedBeta, { registryUrl: fixture.registryUrl });
+
+  await assert.rejects(
+    () => prepareOpenClawTarget(target, { cacheDir: fixture.cacheDir }),
+    /failed integrity verification/,
+  );
+  assert.equal(fs.existsSync(fixture.cacheDir), false);
+});
+
 for (const kind of ["metadata", "archive"]) {
   for (const behavior of ["stalled-headers", "stalled-body", "oversized-declared", "oversized-chunked", "http-error"]) {
     test(`OpenClaw ${kind} ${behavior} releases the response without preparing a cache entry`, { timeout: 3_000 }, async (t) => {

--- a/test/openclaw-version.test.js
+++ b/test/openclaw-version.test.js
@@ -28,14 +28,26 @@ test("eligibility normalization leaves invalid version-like input unchanged", ()
 
 test("official OpenClaw tags resolve to exact versions and prepared targets reuse the cache", async (t) => {
   const fixture = await createRegistryFixture(t);
+  const responses = [];
+  const fetchImpl = async (url, init) => {
+    const response = await fetch(url, init);
+    responses.push(response);
+    return response;
+  };
 
-  const latest = await resolveOpenClawTargetVersion("latest", { registryUrl: fixture.registryUrl });
-  const beta = await resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl });
+  const latest = await resolveOpenClawTargetVersion("latest", { registryUrl: fixture.registryUrl, fetch: fetchImpl });
+  const beta = await resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl, fetch: fetchImpl });
+  assert.deepEqual(fixture.requests, [
+    "/-/package/openclaw/dist-tags",
+    "/openclaw/2026.7.1-2",
+    "/-/package/openclaw/dist-tags",
+    `/openclaw/${affectedBeta}`,
+  ]);
   await assert.rejects(
     () => prepareOpenClawTarget(JSON.parse(JSON.stringify(beta)), { cacheDir: fixture.cacheDir }),
     /directly returned by resolveOpenClawTargetVersion/,
   );
-  const first = await prepareOpenClawTarget(beta, { cacheDir: fixture.cacheDir });
+  const first = await prepareOpenClawTarget(beta, { cacheDir: fixture.cacheDir, fetch: fetchImpl });
   const second = await prepareOpenClawTarget(beta, { cacheDir: fixture.cacheDir });
 
   assert.equal(latest.version, "2026.7.1-2");
@@ -50,6 +62,7 @@ test("official OpenClaw tags resolve to exact versions and prepared targets reus
   assert.equal(first.cache.hit, false);
   assert.equal(second.cache.hit, true);
   assert.equal(fixture.requests.filter((request) => request.startsWith(`/openclaw/-/openclaw-${affectedBeta}.tgz`)).length, 1);
+  assert.ok(responses.every((response) => response.bodyUsed && !response.body.locked));
 });
 
 test("targets without verifiable npm integrity metadata are rejected", async (t) => {
@@ -63,80 +76,62 @@ test("targets without verifiable npm integrity metadata are rejected", async (t)
   );
 });
 
-test("hung OpenClaw metadata fetch is aborted", { timeout: 3_000 }, async (t) => {
-  const fixture = await createRegistryFixture(t, { hangMetadata: true });
-
-  await assert.rejects(
-    () =>
-      resolveOpenClawTargetVersion("latest", {
+for (const kind of ["metadata", "archive"]) {
+  for (const behavior of ["stalled-headers", "stalled-body", "oversized-declared", "oversized-chunked", "http-error"]) {
+    test(`OpenClaw ${kind} ${behavior} releases the response without preparing a cache entry`, { timeout: 3_000 }, async (t) => {
+      const fixture = await createRegistryFixture(t, { [`${kind}Response`]: behavior });
+      const target = kind === "archive"
+        ? await resolveOpenClawTargetVersion(affectedBeta, { registryUrl: fixture.registryUrl })
+        : null;
+      let response;
+      const stalled = behavior.startsWith("stalled");
+      const options = {
         registryUrl: fixture.registryUrl,
-        fetchTimeoutMs: 80,
-      }),
-    (error) => {
-      assert.equal(error.failureClass, "target-download-timeout");
-      assert.match(error.message, /npm metadata download timed out/);
-      return true;
-    },
-  );
-});
-
-test("hung OpenClaw archive fetch is aborted", { timeout: 3_000 }, async (t) => {
-  const fixture = await createRegistryFixture(t, { hangArchive: true });
-  const target = await resolveOpenClawTargetVersion("beta", {
-    registryUrl: fixture.registryUrl,
-    fetchTimeoutMs: 80,
-  });
-
-  await assert.rejects(
-    () =>
-      prepareOpenClawTarget(target, {
         cacheDir: fixture.cacheDir,
-        fetchTimeoutMs: 80,
-      }),
-    (error) => {
-      assert.equal(error.failureClass, "target-download-timeout");
-      assert.match(error.message, /npm archive download timed out/);
-      return true;
-    },
-  );
-});
+        // Non-timeout failures must close the connection before this deadline.
+        fetchTimeoutMs: stalled ? 80 : 10_000,
+        maxMetadataBytes: 64,
+        maxArchiveBytes: 64,
+        fetch: async (url, init) => {
+          response = await fetch(url, init);
+          return response;
+        },
+      };
 
-test("oversized OpenClaw archive is rejected before buffering", { timeout: 3_000 }, async (t) => {
+      await assert.rejects(
+        () => kind === "metadata"
+          ? resolveOpenClawTargetVersion(affectedBeta, options)
+          : prepareOpenClawTarget(target, options),
+        (error) => {
+          if (behavior === "http-error") {
+            assert.match(error.message, /HTTP 503/);
+          } else {
+            assert.equal(error.failureClass, stalled ? "target-download-timeout" : "target-download-too-large");
+            assert.match(error.message, stalled ? /download timed out/ : /64 byte download limit/);
+          }
+          return true;
+        },
+      );
+      if (behavior !== "stalled-headers") {
+        assert.ok(response.bodyUsed, "consume or cancel the actual fetch body");
+        assert.equal(response.body.locked, false, "release the fetch reader");
+      }
+      await fixture.disconnected;
+      assert.equal(fs.existsSync(fixture.cacheDir), false);
+    });
+  }
+}
+
+test("invalid fetch timeout options fall back to a usable deadline", async (t) => {
   const fixture = await createRegistryFixture(t);
-  const target = await resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl });
-  let arrayBufferCalled = false;
-  const fetchImpl = async (url, init) => {
-    const response = await fetch(url, init);
-    if (!String(url).includes(".tgz")) return response;
-    return {
-      ok: true,
-      headers: new Headers({ "content-length": String(2 * 1024 * 1024) }),
-      body: null,
-      async arrayBuffer() {
-        arrayBufferCalled = true;
-        return response.arrayBuffer();
-      },
-    };
-  };
-
-  await assert.rejects(
-    () =>
-      prepareOpenClawTarget(target, {
-        cacheDir: fixture.cacheDir,
-        fetch: fetchImpl,
-        maxArchiveBytes: 1024,
-      }),
-    (error) => {
-      assert.equal(error.failureClass, "target-download-too-large");
-      assert.match(error.message, /download limit/);
-      return true;
-    },
-  );
-  assert.equal(arrayBufferCalled, false);
+  for (const fetchTimeoutMs of [0, -1, 0.5, NaN, Infinity, "invalid", 2 ** 32]) {
+    const target = await resolveOpenClawTargetVersion(affectedBeta, { registryUrl: fixture.registryUrl, fetchTimeoutMs });
+    assert.equal(target.version, affectedBeta);
+  }
 });
 
 test("public CLI aborts a hung --openclaw-version fetch", { timeout: 8_000 }, async (t) => {
-  const fixture = await createRegistryFixture(t, { hangMetadata: true });
+  const fixture = await createRegistryFixture(t, { metadataResponse: "stalled-headers" });
   const pluginRoot = await createHonchoPlugin(t, ">=2026.3.22");
   const cliPath = path.resolve("src/cli.js");
 
@@ -482,6 +477,8 @@ async function createRegistryFixture(t, options = {}) {
   }
 
   const requests = [];
+  let resolveDisconnected;
+  const disconnected = new Promise((resolve) => { resolveDisconnected = resolve; });
   const distTags = { latest: "2026.7.1-2", beta: affectedBeta };
   const distMetadata = {
     integrity: `sha512-${createHash("sha512").update(archive).digest("base64")}`,
@@ -490,15 +487,31 @@ async function createRegistryFixture(t, options = {}) {
   const server = createServer(async (request, response) => {
     requests.push(request.url);
     const requestUrl = new URL(request.url, registryUrl(server));
-    if (options.hangMetadata && (requestUrl.pathname === "/openclaw" || requestUrl.pathname.startsWith("/openclaw/"))) {
+    const behavior = requestUrl.pathname.endsWith(".tgz") ? options.archiveResponse : options.metadataResponse;
+    if (behavior) {
+      response.once("close", resolveDisconnected);
+      if (behavior === "stalled-headers") return;
+      if (behavior === "oversized-declared") {
+        response.setHeader("content-length", "65");
+        response.flushHeaders();
+        return;
+      }
+      if (behavior === "http-error") response.statusCode = 503;
+      response.write(behavior === "oversized-chunked" ? Buffer.alloc(32) : "{");
+      if (behavior === "oversized-chunked") {
+        setImmediate(() => response.write(Buffer.alloc(64)));
+      }
       return;
     }
-    if (options.hangArchive && requestUrl.pathname.endsWith(".tgz")) {
+    if (requestUrl.pathname === "/-/package/openclaw/dist-tags") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(distTags));
       return;
     }
     if (requestUrl.pathname === "/openclaw") {
-      response.setHeader("content-type", "application/json");
-      response.end(JSON.stringify({ "dist-tags": distTags }));
+      // A complete packument need not fit the per-response metadata budget.
+      response.setHeader("content-length", String(16 * 1024 * 1024 + 1));
+      response.flushHeaders();
       return;
     }
     if (requestUrl.pathname === `/openclaw/${affectedBeta}` || requestUrl.pathname === "/openclaw/2026.7.1-2") {
@@ -532,7 +545,7 @@ async function createRegistryFixture(t, options = {}) {
   });
   t.after(() => rm(rootDir, { recursive: true, force: true }));
 
-  return { cacheDir, distMetadata, distTags, registryUrl: registryUrl(server), requests };
+  return { cacheDir, disconnected, distMetadata, distTags, registryUrl: registryUrl(server), requests };
 }
 
 function registryUrl(server) {

--- a/test/openclaw-version.test.js
+++ b/test/openclaw-version.test.js
@@ -63,6 +63,102 @@ test("targets without verifiable npm integrity metadata are rejected", async (t)
   );
 });
 
+test("hung OpenClaw metadata fetch is aborted", { timeout: 3_000 }, async (t) => {
+  const fixture = await createRegistryFixture(t, { hangMetadata: true });
+
+  await assert.rejects(
+    () =>
+      resolveOpenClawTargetVersion("latest", {
+        registryUrl: fixture.registryUrl,
+        fetchTimeoutMs: 80,
+      }),
+    (error) => {
+      assert.equal(error.failureClass, "target-download-timeout");
+      assert.match(error.message, /npm metadata download timed out/);
+      return true;
+    },
+  );
+});
+
+test("hung OpenClaw archive fetch is aborted", { timeout: 3_000 }, async (t) => {
+  const fixture = await createRegistryFixture(t, { hangArchive: true });
+  const target = await resolveOpenClawTargetVersion("beta", {
+    registryUrl: fixture.registryUrl,
+    fetchTimeoutMs: 80,
+  });
+
+  await assert.rejects(
+    () =>
+      prepareOpenClawTarget(target, {
+        cacheDir: fixture.cacheDir,
+        fetchTimeoutMs: 80,
+      }),
+    (error) => {
+      assert.equal(error.failureClass, "target-download-timeout");
+      assert.match(error.message, /npm archive download timed out/);
+      return true;
+    },
+  );
+});
+
+test("oversized OpenClaw archive is rejected before buffering", { timeout: 3_000 }, async (t) => {
+  const fixture = await createRegistryFixture(t);
+  const target = await resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl });
+  let arrayBufferCalled = false;
+  const fetchImpl = async (url, init) => {
+    const response = await fetch(url, init);
+    if (!String(url).includes(".tgz")) return response;
+    return {
+      ok: true,
+      headers: new Headers({ "content-length": String(2 * 1024 * 1024) }),
+      body: null,
+      async arrayBuffer() {
+        arrayBufferCalled = true;
+        return response.arrayBuffer();
+      },
+    };
+  };
+
+  await assert.rejects(
+    () =>
+      prepareOpenClawTarget(target, {
+        cacheDir: fixture.cacheDir,
+        fetch: fetchImpl,
+        maxArchiveBytes: 1024,
+      }),
+    (error) => {
+      assert.equal(error.failureClass, "target-download-too-large");
+      assert.match(error.message, /download limit/);
+      return true;
+    },
+  );
+  assert.equal(arrayBufferCalled, false);
+});
+
+test("public CLI aborts a hung --openclaw-version fetch", { timeout: 8_000 }, async (t) => {
+  const fixture = await createRegistryFixture(t, { hangMetadata: true });
+  const pluginRoot = await createHonchoPlugin(t, ">=2026.3.22");
+  const cliPath = path.resolve("src/cli.js");
+
+  await assert.rejects(
+    () =>
+      execFileAsync(process.execPath, [cliPath, "check", "--plugin-root", pluginRoot, "--openclaw-version", "latest"], {
+        cwd: pluginRoot,
+        timeout: 4_000,
+        env: {
+          ...process.env,
+          PLUGIN_INSPECTOR_CACHE_DIR: fixture.cacheDir,
+          PLUGIN_INSPECTOR_NPM_REGISTRY: fixture.registryUrl,
+          PLUGIN_INSPECTOR_TARGET_FETCH_TIMEOUT_MS: "80",
+        },
+      }),
+    (error) => {
+      assert.match(error.stderr, /npm metadata download timed out/);
+      return true;
+    },
+  );
+});
+
 test("failed target extraction finishes filesystem work before removing its workspace", async (t) => {
   const fixture = await createRegistryFixture(t, { invalidArchiveHeader: true });
   const target = await resolveOpenClawTargetVersion("beta", { registryUrl: fixture.registryUrl });
@@ -394,6 +490,12 @@ async function createRegistryFixture(t, options = {}) {
   const server = createServer(async (request, response) => {
     requests.push(request.url);
     const requestUrl = new URL(request.url, registryUrl(server));
+    if (options.hangMetadata && (requestUrl.pathname === "/openclaw" || requestUrl.pathname.startsWith("/openclaw/"))) {
+      return;
+    }
+    if (options.hangArchive && requestUrl.pathname.endsWith(".tgz")) {
+      return;
+    }
     if (requestUrl.pathname === "/openclaw") {
       response.setHeader("content-type", "application/json");
       response.end(JSON.stringify({ "dist-tags": distTags }));
@@ -424,7 +526,10 @@ async function createRegistryFixture(t, options = {}) {
     response.end("not found");
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  t.after(() => new Promise((resolve) => server.close(resolve)));
+  t.after(() => {
+    server.closeAllConnections();
+    return new Promise((resolve) => server.close(resolve));
+  });
   t.after(() => rm(rootDir, { recursive: true, force: true }));
 
   return { cacheDir, distMetadata, distTags, registryUrl: registryUrl(server), requests };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting an npm OpenClaw target could wait indefinitely for stalled registry or archive responses, or buffer an unbounded download. A metadata limit alone also breaks healthy `latest` and `beta` resolution when the full package history exceeds that limit.

## Why This Change Was Made

Each metadata or archive request uses a 30-second default deadline covering its headers and body reads, not a single deadline for the entire resolution and preparation operation. Invalid, nonpositive, fractional, nonfinite, or overflowing timeout values fall back to that default. Operators can override the budgets with `PLUGIN_INSPECTOR_TARGET_FETCH_TIMEOUT_MS`, `PLUGIN_INSPECTOR_TARGET_METADATA_MAX_BYTES`, and `PLUGIN_INSPECTOR_TARGET_ARCHIVE_MAX_BYTES`.

Tag resolution reads the official flat `/-/package/openclaw/dist-tags` response, then fetches metadata for the resolved exact version. The metadata and archive limits remain 16 MiB and 256 MiB respectively; the full packument is not downloaded.

Declared and streamed oversized bodies are rejected, HTTP-error bodies are cancelled, and acquired readers are released on success and failure. Integrity verification, failed-extraction cleanup, cache behavior, and the requirement to prepare the original resolved target object are preserved.

This follow-up builds directly on SebTardif's original commit `4f1a06ca249c6d49d71d7f259571a11bb1eb879c`; contributor ancestry and authorship are retained. Capture, registration, and synthetic-probe timeout paths are outside this PR.

## User Impact

Healthy tag-based target selection stays within the metadata budget. Stalled or oversized downloads fail with `target-download-timeout` or `target-download-too-large`, without retaining response readers or preparing a failed target.

## Evidence

- Red checkpoint `11b0e89f8d0a33888009b01bc90f2d0700f35f87`: https://github.com/openclaw/plugin-inspector/actions/runs/34367312677. Node 22 CI recorded 12 expected failures covering the packument limit, response cleanup, and timeout overflow; 259 tests passed.
- Green candidate `55bff71c0b5fee15b2e1405253ed7f04f0391433`: https://github.com/openclaw/plugin-inspector/actions/runs/34367826440. Node 22 `npm run check` passed all 272 tests with no skips or cancellations, followed by `package contents: pass`.
- Fresh independent review of the complete staged candidate against base `84ede904fd6e766a9fc4de002f39af87d90c1916` was P2-clean, with no accepted or actionable P0-P2 findings.
- Real HTTP fixtures cover stalled headers and bodies, declared and chunked oversized responses, HTTP-error cancellation, peer disconnects, successful tag resolution and verified archive preparation, cache reuse, integrity mismatch, failed-extraction cleanup, and the public CLI timeout.
- Credential-free live contract read on September 9, 2026, separate from the offline default suite: `/-/package/openclaw/dist-tags` returned HTTP 200, 69 bytes, and a flat object with `latest: "2026.9.3"` and `beta: "2026.9.1"`. `/openclaw/2026.9.3` returned HTTP 200, 108,241 bytes, the matching version, a string tarball URL, and SHA-512 integrity metadata. No full packument or live archive was downloaded.
- Contributor code was executed only in the reviewed secretless fork CI workflow, not locally. The earlier `action_required` run was superseded by approved runs for the updated PR head.

Source-owner review has accepted candidate `55bff71c0b5fee15b2e1405253ed7f04f0391433` and its per-request bounded defaults for merge. No release is included. Downstream Crabpot smoke remains deferred to its separately authorized stage. A real registry outage and a slow-WAN full archive transfer were not tested.
