### PR TITLE
fix: capture plugins that bind model auth during registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Capture plugins that bind `api.runtime.modelAuth` during registration with credential-free defaults; auth acquisition remains an explicit synthetic failure.
+
 ## 0.3.24 - 2026-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ That keeps compatibility CI offline and credential-free. It does not call live
 services, launch OpenClaw, run provider SDKs, or emulate service lifecycle side
 effects.
 
+The default capture `api.runtime.modelAuth` passes synthetic provider IDs through
+unchanged, returns fresh empty auth stores and profile lists, and reports no
+configured API keys. Auth acquisition rejects with a mock-auth-unavailable error;
+it never looks up host credentials. This supports registration and no-auth
+callbacks, not provider alias validation or authenticated execution. An explicitly
+supplied runtime is preserved unchanged, including an empty runtime.
+
 Synthetic probes classify widget presenters as metadata-only. They record the
 registration without calling its match, availability, or presentation callbacks,
 including when channel, provider, or lifecycle execution is enabled.

--- a/src/capture-api.js
+++ b/src/capture-api.js
@@ -203,6 +203,17 @@ function createRuntimeContext(options) {
     logger: options.logger ?? console,
     now: () => new Date(0),
     tts: runtime.tts ?? {},
+    // Synthetic provider IDs pass through; capture never resolves host aliases or credentials.
+    modelAuth: {
+      resolveProviderIdForAuth: (provider) => provider,
+      ensureAuthProfileStore: () => ({ version: 1, profiles: {} }),
+      resolveAuthProfileOrder: () => [],
+      listProfilesForProvider: () => [],
+      isProviderApiKeyConfigured: () => false,
+      getApiKeyForModel: rejectCaptureModelAuth,
+      getRuntimeAuthForModel: rejectCaptureModelAuth,
+      resolveApiKeyForProvider: rejectCaptureModelAuth,
+    },
     state: {
       resolveStateDir: () => options.stateDir ?? process.cwd(),
       openBlobStore(storeOptions) {
@@ -226,6 +237,10 @@ function createRuntimeContext(options) {
       ...(runtime.state ?? {}),
     },
   };
+}
+
+async function rejectCaptureModelAuth() {
+  throw new Error("Model auth is unavailable in capture mocks");
 }
 
 function createBlobStoreContext(options) {

--- a/test/capture-api.test.js
+++ b/test/capture-api.test.js
@@ -164,3 +164,41 @@ test("capture API can retain handlers for probes", () => {
   assert.equal(retained[1].returnValue, service);
   assert.equal(typeof retained[1].returnValue.start, "function");
 });
+
+test("capture modelAuth stays credential-free with fresh stores and lists", async () => {
+  const api = createCaptureApi({
+    env: { OPENAI_API_KEY: "synthetic-not-a-credential" },
+    config: { models: { providers: { fixture: { apiKey: "synthetic-not-a-credential" } } } },
+    secrets: { get() { throw new Error("capture must not look up secrets"); } },
+  });
+  const auth = api.runtime.modelAuth;
+  const other = createCaptureApi().runtime.modelAuth;
+
+  assert.equal(auth.resolveProviderIdForAuth("fixture-provider"), "fixture-provider");
+  assert.equal(auth.isProviderApiKeyConfigured({ provider: "fixture", cfg: api.config }), false);
+  assert.deepEqual(auth.ensureAuthProfileStore(), { version: 1, profiles: {} });
+  auth.ensureAuthProfileStore().profiles.fixture = { apiKey: "synthetic-not-a-credential" };
+  assert.deepEqual(auth.ensureAuthProfileStore(), { version: 1, profiles: {} });
+  assert.deepEqual(other.ensureAuthProfileStore(), { version: 1, profiles: {} });
+  for (const method of ["resolveAuthProfileOrder", "listProfilesForProvider"]) {
+    assert.deepEqual(auth[method]({ provider: "fixture", cfg: api.config }), []);
+    auth[method]({}).push("fixture");
+    assert.deepEqual(auth[method]({}), []);
+    assert.deepEqual(other[method]({}), []);
+  }
+  for (const method of ["getApiKeyForModel", "getRuntimeAuthForModel", "resolveApiKeyForProvider"]) {
+    const result = auth[method]({ provider: "fixture", model: { provider: "fixture" }, cfg: api.config });
+    assert.ok(result instanceof Promise, method);
+    await assert.rejects(result, { message: "Model auth is unavailable in capture mocks" });
+  }
+});
+
+test("capture modelAuth preserves explicitly supplied runtime identity", () => {
+  const modelAuth = { resolveProviderIdForAuth: () => "custom-provider" };
+  for (const runtime of [{ modelAuth }, {}]) {
+    const api = createCaptureApi({ runtime });
+    assert.equal(api.runtime, runtime);
+    assert.equal(api.runtime.modelAuth, runtime.modelAuth);
+  }
+  assert.equal(createCaptureApi({ runtime: { modelAuth } }).runtime.modelAuth.resolveProviderIdForAuth(), "custom-provider");
+});

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -538,6 +538,61 @@ test("capture entrypoint imports a local fixture and records registrations", asy
   );
 });
 
+for (const mockSdk of [false, true]) {
+  test(`capture modelAuth binds a resolver during registration (mockSdk=${mockSdk})`, async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-model-auth-"));
+    const entrypoint = path.join(dir, "fixture.mjs");
+    await writeFile(entrypoint, [
+      "export function register(api) {",
+      "  const { resolveProviderIdForAuth } = api.runtime.modelAuth;",
+      "  api.registerTool({ name: resolveProviderIdForAuth('fixture-provider'), run() {} });",
+      "}",
+    ].join("\n"), "utf8");
+
+    const result = await captureEntrypoint(entrypoint, { mockSdk });
+
+    assert.equal(result.status, "captured");
+    assert.equal(result.captured.length, 1);
+    assert.equal(result.captured[0].name, "registerTool");
+    assert.equal(result.captured[0].arguments[0].name, "fixture-provider");
+  });
+
+  test(`capture modelAuth acquisition remains a registration failure (mockSdk=${mockSdk})`, async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-model-auth-failure-"));
+    const entrypoint = path.join(dir, "fixture.mjs");
+    await writeFile(entrypoint, [
+      "export async function register(api) {",
+      "  await api.runtime.modelAuth.resolveApiKeyForProvider({ provider: 'fixture-provider' });",
+      "}",
+    ].join("\n"), "utf8");
+
+    await assert.rejects(captureEntrypoint(entrypoint, { mockSdk }), (error) => {
+      assert.equal(error.failureClass, "registration-execution-error");
+      assert.match(error.message, /Model auth is unavailable in capture mocks/);
+      return true;
+    });
+  });
+}
+
+test("capture modelAuth retains a supplied runtime through the in-process entrypoint", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-model-auth-custom-"));
+  const entrypoint = path.join(dir, "fixture.mjs");
+  await writeFile(entrypoint, [
+    "export function register(api) {",
+    "  api.registerTool({",
+    "    name: api.runtime.modelAuth.resolveProviderIdForAuth('fixture-provider'),",
+    "    run: () => api.runtime,",
+    "  });",
+    "}",
+  ].join("\n"), "utf8");
+  const runtime = { modelAuth: { resolveProviderIdForAuth: () => "custom-provider" } };
+
+  const result = await captureEntrypoint(entrypoint, { apiOptions: { runtime, retainHandlers: true } });
+
+  assert.equal(result.captured[0].arguments[0].name, "custom-provider");
+  assert.equal(result.retained[0].arguments[0].run(), runtime);
+});
+
 test("capture entrypoint can mock OpenClaw plugin SDK imports", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-mock-sdk-capture-"));
   await mkdir(path.join(dir, "src"), { recursive: true });

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -552,6 +552,44 @@ test("mock SDK windows spawn helpers return concrete invocations", async () => {
   assert.deepEqual(result.results[0].output, { type: "object", keys: ["async", "sync"] });
 });
 
+for (const mockSdk of [false, true]) {
+  test(`synthetic modelAuth executes no-auth handlers and fails uncaught auth (mockSdk=${mockSdk})`, async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-model-auth-"));
+    const entrypoint = path.join(dir, "fixture.mjs");
+    await writeFile(entrypoint, [
+      'import assert from "node:assert/strict";',
+      "export function register(api) {",
+      "  const { resolveProviderIdForAuth, ensureAuthProfileStore, isProviderApiKeyConfigured } = api.runtime.modelAuth;",
+      "  api.registerTool({",
+      "    name: resolveProviderIdForAuth('fixture-provider'),",
+      "    run() {",
+      "      assert.equal(isProviderApiKeyConfigured({ provider: 'fixture-provider' }), false);",
+      "      assert.deepEqual(ensureAuthProfileStore(), { version: 1, profiles: {} });",
+      "      return resolveProviderIdForAuth('fixture-provider');",
+      "    },",
+      "  });",
+      "  api.on('before_tool_call', () => api.runtime.modelAuth.getRuntimeAuthForModel({ model: { provider: 'fixture-provider' } }));",
+      "  const unexpected = () => { throw new Error('opt-in callback executed'); };",
+      "  api.registerService({ name: 'fixture-service', start: unexpected });",
+      "  api.registerChannel({ id: 'fixture-channel', send: unexpected });",
+      "  api.registerSpeechProvider({ id: 'fixture-speech', speak: unexpected });",
+      "}",
+    ].join("\n"), "utf8");
+
+    const result = await runEntrypointSyntheticProbes(entrypoint, { mockSdk });
+
+    assert.deepEqual(result.summary, { probeCount: 5, passCount: 1, failCount: 1, blockedCount: 3 });
+    assert.deepEqual(result.results[0].output, { type: "string", value: "fixture-provider" });
+    assert.equal(result.results[1].status, "fail");
+    assert.equal(result.results[1].error, "Model auth is unavailable in capture mocks");
+    assert.deepEqual(result.results.slice(2).map((item) => item.reason), [
+      "captured registration requires includeLifecycle=true",
+      "captured registration requires includeChannelRuntime=true",
+      "captured registration requires includeProviderCapabilities=true",
+    ]);
+  });
+}
+
 async function captureLocalFixture(lines) {
   const dir = await mkdtemp(path.join(os.tmpdir(), "plugin-inspector-probes-"));
   const entrypoint = path.join(dir, "fixture.mjs");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers with repository write access can edit it. GitHub's fork-collaboration flag is not applicable. This is an unreleased source-only repair; no version bump or package publication is included.

</details>

## What Problem This Solves

Resolves a problem where runtime capture and synthetic probes fail during registration when a plugin binds `api.runtime.modelAuth`. This blocked Crabpot's development fixture capture before callbacks could run.

## Why This Change Was Made

The default capture runtime now supplies the finite eight-method public model-auth namespace. Synthetic provider IDs pass through unchanged, stores and profile lists are fresh and empty, and configured auth is false. All three auth-acquisition methods return rejected Promises with an explicit unavailable error.

The implementation follows the credential-free convention in OpenClaw's public runtime test helper without importing host code or Vitest. Explicitly supplied runtimes retain their identity, including empty runtimes. No SDK mock, classifier, timeout, lifecycle policy, dependency, workflow, or downstream pin changes.

## User Impact

Plugins can bind model-auth helpers during capture and run explicit no-auth callbacks. Requests for credentials still fail visibly. This is not provider alias validation, authenticated provider execution, or real Codex app-server proof.

Crabpot adoption and full lifecycle/dashboard validation remain separate follow-through. Published npm `0.3.24` is unchanged.

## Evidence

Candidate: `94e02502b898a27715da949e4367a7e5e4d0a365`, based on `92db8c57e1d5544c522c7c882a33be1ad4e253b9`.

- New tests against the pre-fix producer: seven intended missing-namespace failures; two supplied-runtime identity tests already pass. Candidate: all nine pass.
- Node 22.23.2: all 60 tests across the three owning files pass; `npm run check` passes all 250 tests and the package-contents guard.
- Packed candidate installed into a separate disposable environment: exported API, actual capture CLI, and retained mock-SDK callbacks execute. No-auth callback returns the concrete provider string; uncaught auth rejection remains a failed probe.
- Historical OpenClaw `c667fa4cd0928f4ce02e394a8544e08957af170d` on Node 24.20.0: old inspector still fails both original workspace commands with `Cannot destructure property 'resolveProviderIdForAuth' of 'undefined' as it is undefined.` The candidate captures 28 contracts; synthetic results are **23 pass, 0 fail, 5 blocked**.
- Those five existing blocked probes remain visible: two service opt-ins, one CLI and two tools without supported callable probes. No reclassification or policy changes.
- Crabpot source-mode smoke with explicit `CRABPOT_PLUGIN_INSPECTOR_DIR`: 59 fixtures, zero breakages. Separate unchanged npm `0.3.24` smoke also passes, but is **old-package smoke, not candidate parity**.
- Independent autoreview of the exact committed patch: scoped-clean through P2, no actionable findings. Signed commit verified; whitespace and private-data diff checks pass.
- Exact-head hosted [Node 22 check](https://github.com/openclaw/plugin-inspector/actions/runs/34218993498) passed.

All fixture/package execution used disposable, non-root, secretless containers without host mounts or forwarded credentials. The original downstream red artifacts and staged Crabpot deletion are preserved.

Production delta: **+15 lines**, justified by the missing finite namespace and one shared rejection helper. Tests: +131; README/changelog: +9. No release metadata or generated-report changes.

This draft is a review checkpoint. Exact-head hosted CI, ClawSweeper findings/Rank-up disposition, current landing gates and parent approval remain required before squash landing. No release dispatch or npm publication is authorized by this PR.
