### PR TITLE
fix: report absent entrypoints before SDK alias blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Capture plugins that bind `api.runtime.modelAuth` during registration with credential-free defaults; auth acquisition remains an explicit synthetic failure.
+- Report absent build output and missing entrypoints before SDK alias blockers in cold-import readiness, preserving build-required totals and all remediation evidence.
 
 ## 0.3.24 - 2026-08-31
 

--- a/src/cold-import-readiness.js
+++ b/src/cold-import-readiness.js
@@ -226,14 +226,14 @@ function readinessStatus(blockers) {
   if (blockers.length === 0) {
     return "ready";
   }
-  if (blockers.some((blocker) => blocker.code === "sdk-alias-required")) {
-    return "sdk-alias-required";
-  }
   if (blockers.some((blocker) => blocker.code === "build-required")) {
     return "build-required";
   }
   if (blockers.some((blocker) => blocker.code === "missing-entrypoint")) {
     return "missing";
+  }
+  if (blockers.some((blocker) => blocker.code === "sdk-alias-required")) {
+    return "sdk-alias-required";
   }
   if (blockers.some((blocker) => blocker.code === "ts-loader-required")) {
     return "ts-loader-required";

--- a/test/cold-import-readiness.test.js
+++ b/test/cold-import-readiness.test.js
@@ -44,31 +44,69 @@ test("cold import readiness classifies entrypoint blockers", async (t) => {
   assert.match(renderColdImportReadinessMarkdown(readiness), /## Entrypoints/);
 });
 
-test("cold import readiness preserves combined blocker evidence", () => {
-  const readiness = buildColdImportReadiness({
-    report: readinessReport(
-      [{ kind: "extension", specifier: "./index.js", relativePath: "index.js", exists: true }],
-      {
-        dependencies: ["left-pad"],
-        sdkImportDetails: [
-          {
-            specifier: "openclaw/plugin-sdk/legacy-helper",
-            ref: "index.js:1",
-          },
-        ],
-      },
-    ),
-  });
-  const entrypoint = readiness.fixtures[0].entrypoints[0];
+test("cold import readiness preserves combined blocker evidence", async (t) => {
+  const cases = [
+    {
+      name: "SDK alias precedes dependencies for an existing entrypoint",
+      entrypoint: { kind: "extension", specifier: "./index.js", relativePath: "index.js", exists: true },
+      status: "sdk-alias-required",
+      blocker: "dependency-install-required",
+      assertion: "fixture dependencies are installed in an isolated workspace before cold import",
+      buildRequiredCount: 0,
+      dependencyInstallRequiredCount: 1,
+    },
+    {
+      name: "absent build output precedes SDK alias",
+      entrypoint: { kind: "extension", specifier: "./dist/index.js", relativePath: "dist/index.js", exists: false, requiresBuild: true },
+      status: "build-required",
+      blocker: "build-required",
+      assertion: "plugin build or source alias resolution runs before cold import",
+      buildRequiredCount: 1,
+      dependencyInstallRequiredCount: 0,
+    },
+    {
+      name: "absent plain entrypoint precedes SDK alias",
+      entrypoint: { kind: "extension", specifier: "./missing.js", relativePath: "missing.js", exists: false },
+      status: "missing",
+      blocker: "missing-entrypoint",
+      assertion: "plugin package metadata points at an existing OpenClaw entrypoint",
+      buildRequiredCount: 0,
+      dependencyInstallRequiredCount: 0,
+    },
+  ];
 
-  assert.equal(entrypoint.status, "sdk-alias-required");
-  assert.deepEqual(
-    entrypoint.blockers.map((blocker) => blocker.code),
-    ["dependency-install-required", "sdk-alias-required"],
-  );
-  assert.equal(readiness.summary.dependencyInstallRequiredCount, 1);
-  assert.equal(readiness.summary.sdkAliasRequiredCount, 1);
-  assert.deepEqual(validateColdImportReadiness(readiness), []);
+  for (const fixture of cases) {
+    await t.test(fixture.name, () => {
+      const readiness = buildColdImportReadiness({
+        report: readinessReport([fixture.entrypoint], {
+          dependencies: ["left-pad"],
+          sdkImportDetails: [
+            {
+              specifier: "openclaw/plugin-sdk/legacy-helper",
+              ref: "index.js:1",
+            },
+          ],
+        }),
+      });
+      const entrypoint = readiness.fixtures[0].entrypoints[0];
+
+      assert.deepEqual(
+        { status: entrypoint.status, buildRequiredCount: readiness.summary.buildRequiredCount },
+        { status: fixture.status, buildRequiredCount: fixture.buildRequiredCount },
+      );
+      assert.deepEqual(
+        entrypoint.blockers.map((blocker) => blocker.code),
+        [fixture.blocker, "sdk-alias-required"],
+      );
+      assert.deepEqual(entrypoint.assertions, [
+        fixture.assertion,
+        "target OpenClaw exports the imported SDK alias or provides a migration shim",
+      ]);
+      assert.equal(readiness.summary.dependencyInstallRequiredCount, fixture.dependencyInstallRequiredCount);
+      assert.equal(readiness.summary.sdkAliasRequiredCount, 1);
+      assert.deepEqual(validateColdImportReadiness(readiness), []);
+    });
+  }
 });
 
 test("cold import readiness treats openclaw as a host-linked dependency", () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users reviewing cold-import readiness would see an SDK alias blocker instead of an absent entrypoint when both blockers were present. Missing build output also disappeared from the build-required summary count.

## Why This Change Was Made

Give absent build output and missing entrypoints precedence over SDK alias blockers. Keep every blocker and remediation assertion, all report fields and finding codes, and the remaining precedence unchanged. The changelog records the corrected report behavior.

## User Impact

Readiness reports now identify the missing build output or entrypoint first without hiding the SDK work that remains. Existing entrypoints with both SDK alias and dependency blockers still report `sdk-alias-required`.

## Evidence

- Red on unchanged production code: the new absent-build case returned `sdk-alias-required` and `buildRequiredCount: 0` instead of `build-required` and `1`; the absent plain entrypoint returned `sdk-alias-required` instead of `missing`. The existing SDK-plus-dependency case passed.
- Green after the fix: `node --test test/cold-import-readiness.test.js` passed all 7 tests, including both new cases and the existing precedence case.
- `node --test --test-name-pattern='cold import readiness' test/api.test.js` passed the focused public API readiness test.
- Both changed JavaScript files passed `node --check`; `git diff --check` passed. Local runtime: Node 24.19.0.
- Fresh read-only P2 review found no actionable findings.

Scope is limited to cold-readiness status ordering, its existing combined-blocker test, and the changelog. No CLI, CommonJS, inspector, target-fetching, or child-lifecycle changes.

The coordinating maintainer reviewed and accepted the exact source, test, and changelog diff at `2876b4854b35586d5905f372907249968f22d29d`. Check / Node 22 passed on that head. This is a source-only repair; Crabpot smoke and release followthrough remain pending with the coordinated release lane.
