### PR TITLE
fix: recognize metadata-only OpenClaw registrars in synthetic probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Capture plugins that bind `api.runtime.modelAuth` during registration with credential-free defaults; auth acquisition remains an explicit synthetic failure.
+- Recognize board widget content kinds, memory prompt preparation, transcript source providers, worker providers, and MCP server connection resolvers as metadata-only synthetic probes without invoking runtime callbacks.
 
 ## 0.3.24 - 2026-08-31
 

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -46,6 +46,11 @@ export const syntheticRegistrationExecutionProfiles = {
     callableProperties: [],
     reason: "auto-enable probes are captured as registration metadata before runtime activation checks",
   },
+  registerBoardWidgetContentKind: {
+    mode: "metadata-only",
+    callableProperties: [],
+    reason: "board widget content kinds are captured as registration metadata before source validation or document composition",
+  },
   registerCli: {
     mode: "direct",
     callableProperties: ["handler", "run", "execute"],
@@ -125,6 +130,16 @@ export const syntheticRegistrationExecutionProfiles = {
     mode: "metadata-only",
     callableProperties: [],
     reason: "hosted media resolvers are captured as registration metadata before media URL resolution",
+  },
+  registerMcpServerConnectionResolver: {
+    mode: "metadata-only",
+    callableProperties: [],
+    reason: "MCP server connection resolvers are captured as registration metadata before requester-bound transport resolution",
+  },
+  registerMemoryPromptPreparation: {
+    mode: "metadata-only",
+    callableProperties: [],
+    reason: "memory prompt preparation callbacks are captured as registration metadata before prompt-runtime execution",
   },
   registerMemoryPromptSection: {
     mode: "metadata-only",
@@ -275,6 +290,11 @@ export const syntheticRegistrationExecutionProfiles = {
     callableProperties: [],
     reason: "text transforms are captured as registration metadata before content mutation execution",
   },
+  registerTranscriptSourceProvider: {
+    mode: "metadata-only",
+    callableProperties: [],
+    reason: "transcript source providers are captured as registration metadata before live capture or transcript import",
+  },
   registerVideoGenerationProvider: {
     mode: "metadata-only",
     callableProperties: [],
@@ -299,6 +319,11 @@ export const syntheticRegistrationExecutionProfiles = {
     mode: "metadata-only",
     callableProperties: [],
     reason: "widget presenters are captured as registration metadata before presentation runtime execution",
+  },
+  registerWorkerProvider: {
+    mode: "metadata-only",
+    callableProperties: [],
+    reason: "worker providers are captured as registration metadata before cloud-worker lifecycle execution",
   },
 };
 

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -114,6 +114,7 @@ test("synthetic probe plan classifies generated kitchen-sink registrars", () => 
     "registerAgentHarness",
     "registerAgentToolResultMiddleware",
     "registerAutoEnableProbe",
+    "registerBoardWidgetContentKind",
     "registerChannel",
     "defineBundledChannelEntry",
     "registerCli",
@@ -133,12 +134,14 @@ test("synthetic probe plan classifies generated kitchen-sink registrars", () => 
     "registerHttpRoute",
     "registerImageGenerationProvider",
     "registerInteractiveHandler",
+    "registerMcpServerConnectionResolver",
     "registerMediaUnderstandingProvider",
     "registerMeetingNotesSourceProvider",
     "registerMemoryCapability",
     "registerMemoryCorpusSupplement",
     "registerMemoryEmbeddingProvider",
     "registerMemoryFlushPlan",
+    "registerMemoryPromptPreparation",
     "registerMemoryPromptSection",
     "registerMemoryPromptSupplement",
     "registerMemoryRuntime",
@@ -163,11 +166,13 @@ test("synthetic probe plan classifies generated kitchen-sink registrars", () => 
     "registerTextTransforms",
     "registerTool",
     "registerToolMetadata",
+    "registerTranscriptSourceProvider",
     "registerTrustedToolPolicy",
     "registerVideoGenerationProvider",
     "registerWebFetchProvider",
     "registerWebSearchProvider",
     "registerWidgetPresenter",
+    "registerWorkerProvider",
   ];
   const plan = buildSyntheticProbePlan({
     capture: {
@@ -194,12 +199,12 @@ test("synthetic probe plan classifies generated kitchen-sink registrars", () => 
   assert.deepEqual(validateSyntheticProbePlan(plan), []);
 });
 
-test("synthetic probes capture widget presenters without invoking runtime callbacks", async () => {
+test("synthetic probes capture metadata-only registrars without invoking runtime callbacks", async () => {
   const api = createCaptureApi({ retainHandlers: true });
   const invoked = [];
   const callback = (name) => () => { invoked.push(name); };
-  for (const target of ["current_channel", "node_panel"]) {
-    api.registerWidgetPresenter({
+  const registrations = [
+    ...["current_channel", "node_panel"].map((target) => ["registerWidgetPresenter", {
       target,
       description: `Fixture ${target}`,
       availability: callback(`${target}.availability`),
@@ -207,21 +212,72 @@ test("synthetic probes capture widget presenters without invoking runtime callba
       ...(target === "current_channel"
         ? { match: callback(`${target}.match`), capabilities: { sourceKinds: ["html"] } }
         : {}),
-    });
+    }]),
+    ["registerBoardWidgetContentKind", {
+      kind: "fixture",
+      label: "Fixture",
+      resources: {
+        surface: "fixture",
+        paths: [],
+        readPublicResource: callback("board.readPublicResource"),
+      },
+      validateSource: callback("board.validateSource"),
+      composeDocument: callback("board.composeDocument"),
+    }],
+    ["registerMemoryPromptPreparation", async () => {
+      invoked.push("memory.prepare");
+      return [];
+    }],
+    ["registerTranscriptSourceProvider", {
+      id: "fixture",
+      name: "Fixture",
+      sourceKinds: ["live-audio", "posthoc-transcript"],
+      start: callback("transcript.start"),
+      watchOccupancy: callback("transcript.watchOccupancy"),
+      stop: callback("transcript.stop"),
+      status: callback("transcript.status"),
+      importTranscript: callback("transcript.importTranscript"),
+    }],
+    ["registerWorkerProvider", {
+      id: "fixture",
+      resolveAllocation: callback("worker.resolveAllocation"),
+      provision: callback("worker.provision"),
+      inspect: callback("worker.inspect"),
+      renew: callback("worker.renew"),
+      destroy: callback("worker.destroy"),
+    }],
+    ["registerMcpServerConnectionResolver", {
+      serverName: "fixture",
+      resolve: callback("mcp.resolve"),
+    }],
+  ];
+  for (const [registrar, argument] of registrations) {
+    api[registrar](argument);
   }
   const capture = {
     status: "captured",
     captured: api.getCapturedContracts(),
     retained: api.getRetainedContracts(),
   };
+  assert.deepEqual(capture.captured.map((entry) => entry.name), registrations.map(([registrar]) => registrar));
+  assert.equal(capture.retained.length, registrations.length);
+  for (const [index, [registrar, argument]] of registrations.entries()) {
+    assert.equal(capture.retained[index].name, registrar);
+    assert.equal(capture.retained[index].arguments[0], argument);
+  }
 
   for (const options of [{}, { includeLifecycle: true, includeChannelRuntime: true, includeProviderCapabilities: true }]) {
     const result = await runCapturedSyntheticProbes(capture, options);
 
-    assert.deepEqual(result.summary, { probeCount: 2, passCount: 2, failCount: 0, blockedCount: 0 });
+    assert.deepEqual(result.summary, {
+      probeCount: registrations.length,
+      passCount: registrations.length,
+      failCount: 0,
+      blockedCount: 0,
+    });
     assert.deepEqual(
       result.results.map((item) => [item.seam, item.output.mode]),
-      [["registerWidgetPresenter", "metadata-only"], ["registerWidgetPresenter", "metadata-only"]],
+      registrations.map(([registrar]) => [registrar, "metadata-only"]),
     );
     assert.deepEqual(invoked, []);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting plugins that register board widget content kinds, memory prompt preparation, transcript sources, workers, or MCP connection resolvers receive blocked synthetic probes because these known OpenClaw registrars are unclassified.

## Why This Change Was Made

Classify these five registrars as `metadata-only`, each with an owner-specific reason and no callable properties:

- `registerBoardWidgetContentKind`
- `registerMemoryPromptPreparation`
- `registerTranscriptSourceProvider`
- `registerWorkerProvider`
- `registerMcpServerConnectionResolver`

The signatures were checked against the public [OpenClaw plugin API](https://github.com/openclaw/openclaw/blob/main/src/plugins/plugin-api.types.ts). In particular, memory prompt preparation accepts a function directly; it is not an object-descriptor registration.

The existing early metadata-only return remains unchanged. No callbacks, SDK implementations, execution modes, or opt-in behavior are added. Existing widget presenter coverage and shipped registrar classifications are preserved.

## User Impact

These registrations now produce explicitly labeled metadata-only results instead of unknown-registrar blockers. Their original arguments and callbacks remain captured without being invoked, including with all existing runtime opt-in flags enabled. A metadata-only pass does not establish host acceptance or runtime capability correctness.

## Evidence

- Red: both extended tests fail against the pre-fix source. The kitchen-sink plan reports five blocked registrars; the captured-probe case reports two metadata passes and five blocked entries.
- Green: `node --test test/synthetic-probes.test.js` passes all 18 tests. The extended existing case checks retained argument identity, all five registrations plus both widget presenter variants, metadata-only results, and zero callback invocations with default settings and with `includeLifecycle`, `includeChannelRuntime`, and `includeProviderCapabilities` all enabled.
- `npm run check` passes all 259 tests and the package-contents check on Node 24.19.0. [Node 22 CI](https://github.com/openclaw/plugin-inspector/actions/runs/34367648412) also passed the reviewed head `f54226fcf43280758c5a8750357b863ba4b868b5`.
- The complete source, test, and changelog diff at that head was reviewed and approved for landing. Fresh independent P2 review found no actionable findings.
- After [PR71](https://github.com/openclaw/plugin-inspector/pull/71) landed, a merge from main preserved both conflicting changelog bullets. The resulting head is `e774a324a35dd19bc44f5f1b8c32f48bee81f52b`; the approved production/test patch is unchanged, and PR71's implementation and tests are preserved unchanged. This mechanical resolution was independently verified and approved, retaining the P2 review.
- [Node 22 CI on the final head](https://github.com/openclaw/plugin-inspector/actions/runs/34368049232) passed after the merge from main.
- `git diff --check` passes. Scope against current main remains the profile map, two existing tests, and one unreleased changelog entry. No capture or probe execution logic changes.

No live OpenClaw callback execution or runtime proof is claimed. Crabpot pin/docs/smoke followthrough is reserved for the consolidated release integration and has not been run for this change.
