### PR TITLE
fix: report truthful synthetic Gateway responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Invoke each synthetic Gateway method once, including registrations with options, and validate its first emitted response's JSON wire representation instead of treating any nonthrowing callback as successful. Preserve explicit response authority, returned-payload fallback, deferred replies within the existing deadline, and accepted-only initial responses.
 - Bound synthetic callback waits and cancellation, stop dependent probes after a timeout, and supervise CLI capture plus retained callbacks in one child. Validate report shape and counts before delivery while preserving complete failed-row reports, bounded plugin output, and in-process callback identity. Thanks @SebTardif.
 - Run `registerService` start, stop, and dispose probes serially so teardown cannot overlap startup.
 - Bound real-SDK CLI capture in an owned child, including stalled imports, busy registration, and retained timers. Give in-process capture a finite 30-second default deadline while preserving caller runtime and handler identity; arbitrary in-process JavaScript cannot be forcibly canceled. Thanks @SebTardif.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,27 @@ late promise settlement, but cannot preempt synchronous JavaScript or arbitrary
 plugin side effects. Programmatic probes stay in-process and preserve caller
 runtime objects and retained callback identity.
 
+Gateway method probes invoke each registered handler once, including positional
+`(method, handler, options)` registrations; captured `handler`/`run`/`execute`
+aliases do not create extra calls. The handler receives synthetic Gateway
+options and a void `respond(ok, payload, error, meta)` callback. Existing
+`registrationProbeInputs` overrides remain available.
+
+The first emitted response is authoritative, even when malformed. Probes check
+its JSON-serialized response/error shape: `ok: true` passes, `ok: false` fails,
+and later responses cannot overwrite the outcome. Logging `meta` is not a wire
+field. Without an explicit response, a non-`undefined` return is adapted into a
+successful payload, including `false`, `null`, and `{ ok: false }`, matching the
+OpenClaw plugin registrar. A void handler can respond later within the existing
+probe deadline; no response or return before that deadline fails. Handler throws,
+rejections, and timeouts still fail under the ordinary probe rules.
+
+This observes the initial RPC response plus ordinary handler settlement within
+the existing deadline. It does not prove asynchronous operation completion,
+transport delivery, or authorization. An accepted-only success is valid once the
+handler settles; probes do not implicitly request `expectFinal` or reject legal
+multi-frame methods. No Gateway connection or live host call is made.
+
 `synthetic-probes-cli.js` runs capture and retained callbacks together in one
 owned child. Its whole-child budget also defaults to 30 seconds, including
 imports and registration, with `PLUGIN_INSPECTOR_PROBE_TIMEOUT_MS`,

--- a/src/synthetic-probes.js
+++ b/src/synthetic-probes.js
@@ -509,6 +509,7 @@ export const defaultSyntheticRegistrationProbeInputs = {
   registerGatewayMethod: {
     execute: gatewayProbeArgs,
     handler: gatewayProbeArgs,
+    invoke: gatewayProbeArgs,
     run: gatewayProbeArgs,
   },
   registerHttpRoute: {
@@ -797,7 +798,9 @@ async function runRegistrationProbes(entry, retainedEntry, captureIndex, options
   }
 
   const descriptor =
-    retainedEntry.arguments?.find((value) => value && typeof value === "object") ?? retainedEntry.returnValue;
+    entry.name === "registerGatewayMethod" && typeof retainedEntry.arguments?.[0] === "string"
+      ? retainedEntry.returnValue
+      : retainedEntry.arguments?.find((value) => value && typeof value === "object") ?? retainedEntry.returnValue;
   if (!descriptor || typeof descriptor !== "object") {
     return [blockedResult(entry, captureIndex, "captured registration has no object descriptor")];
   }
@@ -849,18 +852,98 @@ function registrationInvocations(registrar, descriptor, returnValue, profile, op
     if (typeof callable === "function") {
       invocations.push({
         label: `${registrar}.${property}`,
-        invoke: () => invokeRegistrationCallable(callable, registrar, property, options),
+        invoke: () => registrar === "registerGatewayMethod"
+          ? invokeGatewayCallable(callable, property, descriptor, options)
+          : invokeRegistrationCallable(callable, registrar, property, options),
       });
+      // Gateway aliases describe one method, not independent lifecycle callbacks.
+      if (registrar === "registerGatewayMethod") break;
     }
   }
   return invocations;
 }
 
-function invokeRegistrationCallable(callable, registrar, property, options) {
-  const event = syntheticRegistrationEvent(registrar, property, options);
+function invokeRegistrationCallable(
+  callable, registrar, property, options,
+  event = syntheticRegistrationEvent(registrar, property, options),
+) {
   const inputFactory = options.registrationProbeInputs?.[registrar]?.[property] ?? defaultSyntheticRegistrationProbeInputs[registrar]?.[property];
   const args = inputFactory ? inputFactory(event, options) : [event];
   return callable(...args);
+}
+
+async function invokeGatewayCallable(callable, property, descriptor, options) {
+  let responded = false;
+  let closed = false;
+  let resolveResponse;
+  const response = new Promise((resolve) => { resolveResponse = resolve; });
+  const onAbort = () => {
+    closed = true;
+    resolveResponse({ error: options.signal.reason });
+  };
+  options.signal.addEventListener("abort", onAbort, { once: true });
+  const respond = (ok, payload, error) => {
+    if (closed || responded) return;
+    // Snapshot the first emission, including invalid frames. Later responses
+    // cannot recover it; logging metadata is not part of the wire envelope.
+    responded = true;
+    try {
+      resolveResponse({ frame: gatewayResponseFrame(ok, payload, error) });
+    } catch (error) {
+      resolveResponse({ error });
+    }
+  };
+  try {
+    options.signal.throwIfAborted();
+    const event = {
+      ...syntheticRegistrationEvent("registerGatewayMethod", property, options),
+      method: descriptor.method ?? descriptor.name,
+      respond,
+    };
+    const result = await invokeRegistrationCallable(callable, "registerGatewayMethod", property, options, event);
+    // OpenClaw's plugin registrar adapts returns only without an explicit reply.
+    if (!responded && result !== undefined) respond(true, result);
+    // A void handler may respond later. The existing probe deadline bounds this
+    // observation as well as handler settlement; it owns timeout/cancellation.
+    const outcome = await response;
+    if (outcome.error) throw outcome.error;
+    if (!outcome.frame.ok) {
+      throw new Error(`Gateway response error: ${outcome.frame.error?.message ?? "request failed"}`);
+    }
+    return outcome.frame;
+  } finally {
+    closed = true;
+    options.signal.removeEventListener("abort", onAbort);
+  }
+}
+
+function gatewayResponseFrame(ok, payload, error) {
+  let frame;
+  try {
+    frame = JSON.parse(JSON.stringify({ type: "res", id: "fixture-request", ok, payload, error }));
+  } catch {
+    throw new Error("Gateway response is not JSON serializable");
+  }
+  // ResponseFrameSchema / ErrorShapeSchema in OpenClaw v2026.9.3. Payload and
+  // error are optional independently of ok; error codes are nonempty strings.
+  const responseError = frame.error;
+  if (
+    typeof frame.ok !== "boolean" ||
+    (responseError !== undefined && (
+      !responseError ||
+      typeof responseError !== "object" ||
+      Array.isArray(responseError) ||
+      typeof responseError.code !== "string" || responseError.code.length === 0 ||
+      typeof responseError.message !== "string" || responseError.message.length === 0 ||
+      (responseError.retryable !== undefined && typeof responseError.retryable !== "boolean") ||
+      (responseError.retryAfterMs !== undefined &&
+        (!Number.isInteger(responseError.retryAfterMs) || responseError.retryAfterMs < 0)) ||
+      Object.keys(responseError).some((key) => !["code", "message", "details", "retryable", "retryAfterMs"].includes(key))
+    ))
+  ) {
+    throw new Error("Gateway response is malformed");
+  }
+  return frame;
 }
 
 function syntheticRegistrationEvent(registrar, property, options) {
@@ -932,18 +1015,15 @@ function commandProbeArgs(event, options = {}) {
   ];
 }
 
-function gatewayProbeArgs(event) {
+function gatewayProbeArgs(event, options = {}) {
   return [
     {
       ...event,
-      params: event.params,
-      body: event.body,
-      headers: event.headers,
-      respond: event.respond,
-    },
-    {
-      source: event.source,
-      logger: console,
+      req: { type: "req", id: "fixture-request", method: event.method ?? "fixture.gateway.method", params: event.params },
+      client: null,
+      isWebchatConnect: () => false,
+      context: { source: event.source, logger: console },
+      signal: options.signal,
     },
   ];
 }

--- a/test/synthetic-probes.test.js
+++ b/test/synthetic-probes.test.js
@@ -402,8 +402,6 @@ test("synthetic probes pass channel envelopes and gateway responders", async () 
       "pass:registerChannel.send",
       "pass:registerChannel.receive",
       "pass:registerGatewayMethod.handler",
-      "pass:registerGatewayMethod.run",
-      "pass:registerGatewayMethod.execute",
     ],
   );
 });
@@ -423,10 +421,196 @@ test("synthetic probes can execute string plus handler registrations", async () 
     result.results.map((item) => `${item.status}:${item.label}`),
     [
       "pass:registerGatewayMethod.handler",
-      "pass:registerGatewayMethod.run",
-      "pass:registerGatewayMethod.execute",
     ],
   );
+});
+
+test("Gateway probes invoke each logical registration once, including positional options", async (t) => {
+  for (const withOptions of [false, true]) {
+    await t.test(`options=${withOptions}`, async () => {
+      let calls = 0;
+      const handler = () => { calls += 1; return { healthy: true }; };
+      const capture = captureRetained((api) => {
+        const args = withOptions ? [{ scope: "operator.read" }] : [];
+        api.registerGatewayMethod("fixture.first", handler, ...args);
+        api.registerGatewayMethod("fixture.second", handler, ...args);
+      });
+      const result = await runCapturedSyntheticProbes(capture);
+      assert.equal(calls, 2);
+      assert.deepEqual(result.results.map((row) => [row.label, row.status]), [
+        ["registerGatewayMethod.handler", "pass"],
+        ["registerGatewayMethod.handler", "pass"],
+      ]);
+    });
+  }
+});
+
+test("Gateway probes pass one host-shaped options object and a void responder", async () => {
+  let received;
+  const capture = captureRetained((api) => api.registerGatewayMethod("fixture.ping", (...args) => {
+    received = args;
+    assert.equal(args[0].respond(true, { healthy: true }), undefined);
+  }));
+  const result = await runCapturedSyntheticProbes(capture);
+  assert.equal(result.summary.passCount, 1, JSON.stringify(result.results));
+  assert.equal(received.length, 1);
+  const [options] = received;
+  assert.deepEqual(options.req, { type: "req", id: "fixture-request", method: "fixture.ping", params: {} });
+  assert.equal(options.client, null);
+  assert.equal(options.isWebchatConnect(null), false);
+  assert.equal(typeof options.context, "object");
+  assert.equal(options.signal.aborted, false);
+  assert.deepEqual(result.results[0].output, { type: "object", keys: ["id", "ok", "payload", "type"] });
+});
+
+test("Gateway probes preserve object aliases and explicit input overrides", async () => {
+  const params = { fixture: "custom" };
+  const context = { fixture: "context" };
+  let calls = 0;
+  const handler = (options) => {
+    calls += 1;
+    assert.equal(options.params, params);
+    assert.equal(options.context, context);
+    options.respond(true, params);
+  };
+  const capture = captureRetained((api) => api.registerGatewayMethod({
+    name: "fixture.custom", run: handler, execute: handler,
+  }));
+  const result = await runCapturedSyntheticProbes(capture, {
+    registrationProbeInputs: {
+      registerGatewayMethod: {
+        run: (event) => [{ ...event, params, context }],
+      },
+    },
+  });
+  assert.equal(calls, 1);
+  assert.equal(result.results[0].label, "registerGatewayMethod.run");
+  assert.equal(result.summary.passCount, 1, JSON.stringify(result.results));
+});
+
+test("Gateway probes adapt non-undefined return values as successful payloads", async (t) => {
+  for (const payload of [false, null, 0, "", { ok: false }]) {
+    await t.test(JSON.stringify(payload), async () => {
+      const capture = captureRetained((api) => api.registerGatewayMethod("fixture.return", () => payload));
+      const result = await runCapturedSyntheticProbes(capture);
+      assert.equal(result.summary.passCount, 1);
+      assert.deepEqual(result.results[0].output, { type: "object", keys: ["id", "ok", "payload", "type"] });
+    });
+  }
+});
+
+test("Gateway probes judge the first emitted response, without implicit expectFinal", async (t) => {
+  const error = { code: "PLUGIN_SPECIFIC", message: "fixture rejection" };
+  const cases = [
+    ["accepted only", ({ respond }) => { respond(true, { status: "accepted" }); }, "pass"],
+    ["explicit error", ({ respond }) => { respond(false, undefined, error); }, "fail", /fixture rejection/],
+    ["error without details", ({ respond }) => { respond(false); }, "fail", /Gateway.*error/i],
+    ["explicit error overrides return", ({ respond }) => { respond(false, undefined, error); return "ignored"; }, "fail", /fixture rejection/],
+    ["explicit success overrides unserializable return", ({ respond }) => { respond(true); return 1n; }, "pass"],
+    ["success then error", ({ respond }) => { respond(true); respond(false, undefined, error); }, "pass"],
+    ["error then success", ({ respond }) => { respond(false, undefined, error); respond(true); }, "fail", /fixture rejection/],
+    ["malformed then success", ({ respond }) => { respond("yes"); respond(true); }, "fail", /malformed/i],
+    ["success then malformed", ({ respond }) => { respond(true); respond("yes"); }, "pass"],
+    ["success with optional error", ({ respond }) => { respond(true, null, error); }, "pass"],
+    ["logging metadata is not wire payload", ({ respond }) => { respond(true, null, undefined, { ignored: 1n }); }, "pass"],
+  ];
+  for (const [name, handler, status, message] of cases) {
+    await t.test(name, async () => {
+      const capture = captureRetained((api) => api.registerGatewayMethod("fixture.response", handler));
+      const result = await runCapturedSyntheticProbes(capture);
+      assert.equal(result.results[0].status, status, JSON.stringify(result.results));
+      assert.equal(result.results.length, 1);
+      if (message) assert.match(result.results[0].error, message);
+    });
+  }
+});
+
+test("Gateway probes validate the serialized response and error schema", async (t) => {
+  const circular = {};
+  circular.self = circular;
+  const validError = { code: " ", message: " ", details: null, retryable: false, retryAfterMs: 0 };
+  const cases = [
+    ["optional payload", (respond) => respond(true), "pass"],
+    ["nonempty strings are not trimmed", (respond) => respond(true, undefined, validError), "pass"],
+    ["payload uses JSON serialization", (respond) => respond(true, { toJSON: () => "serialized" }), "pass"],
+    ["non-boolean ok", (respond) => respond(1), "fail"],
+    ["null error", (respond) => respond(true, undefined, null), "fail"],
+    ["empty code", (respond) => respond(true, undefined, { code: "", message: "error" }), "fail"],
+    ["missing message", (respond) => respond(true, undefined, { code: "CUSTOM" }), "fail"],
+    ["invalid retryable", (respond) => respond(true, undefined, { ...validError, retryable: "yes" }), "fail"],
+    ["negative retryAfterMs", (respond) => respond(true, undefined, { ...validError, retryAfterMs: -1 }), "fail"],
+    ["fractional retryAfterMs", (respond) => respond(true, undefined, { ...validError, retryAfterMs: 1.5 }), "fail"],
+    ["extra error field", (respond) => respond(true, undefined, { ...validError, extra: true }), "fail"],
+    ["BigInt payload", (respond) => respond(true, 1n), "fail"],
+    ["circular payload", (respond) => respond(true, circular), "fail"],
+    ["unserializable error details", (respond) => respond(true, undefined, { ...validError, details: 1n }), "fail"],
+  ];
+  for (const [name, emit, status] of cases) {
+    await t.test(name, async () => {
+      const capture = captureRetained((api) => api.registerGatewayMethod("fixture.schema", ({ respond }) => { emit(respond); }));
+      const result = await runCapturedSyntheticProbes(capture);
+      assert.equal(result.results[0].status, status, JSON.stringify(result.results));
+      if (status === "fail") assert.match(result.results[0].error, /malformed|serializ/i);
+    });
+  }
+  for (const payload of [1n, circular]) {
+    const capture = captureRetained((api) => api.registerGatewayMethod("fixture.return", () => payload));
+    const result = await runCapturedSyntheticProbes(capture);
+    assert.equal(result.results[0].status, "fail");
+    assert.match(result.results[0].error, /serializ/i);
+  }
+});
+
+test("Gateway probes observe deferred responses within the existing deadline", { timeout: 3000 }, async () => {
+  let emit;
+  let started;
+  const invoked = new Promise((resolve) => { started = resolve; });
+  const capture = captureRetained((api) => api.registerGatewayMethod("fixture.deferred", ({ respond }) => {
+    emit = respond;
+    started();
+  }));
+  let settled = false;
+  const pending = runCapturedSyntheticProbes(capture, { timeoutMs: 1000 }).then((result) => {
+    settled = true;
+    return result;
+  });
+  await invoked;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false);
+  assert.equal(emit(true, { deferred: true }), undefined);
+  const result = await pending;
+  assert.equal(result.summary.passCount, 1);
+});
+
+test("Gateway probes fail missing responses and retain timeout dependency blocking", { timeout: 3000 }, async () => {
+  let later = 0;
+  let emit;
+  const capture = captureRetained((api) => {
+    api.registerGatewayMethod("fixture.missing", ({ respond }) => { emit = respond; });
+    api.registerCommand({ name: "later", handler() { later += 1; } });
+  });
+  const result = await runCapturedSyntheticProbes(capture, { timeoutMs: 25 });
+  assert.equal(result.results[0].status, "fail");
+  assert.match(result.results[0].error, /timed out after 25ms/);
+  assert.equal(result.results[1].status, "blocked");
+  assert.equal(later, 0);
+  assert.equal(emit(true), undefined);
+  assert.equal(result.results[0].status, "fail");
+});
+
+test("Gateway probes preserve thrown, rejected, and hanging handler outcomes after a response", { timeout: 3000 }, async (t) => {
+  for (const [name, handler, error] of [
+    ["throw", ({ respond }) => { respond(true); throw new Error("handler threw"); }, /handler threw/],
+    ["reject", async ({ respond }) => { respond(true); throw new Error("handler rejected"); }, /handler rejected/],
+    ["hang", ({ respond }) => { respond(true); return new Promise(() => {}); }, /timed out after 25ms/],
+  ]) {
+    await t.test(name, async () => {
+      const capture = captureRetained((api) => api.registerGatewayMethod("fixture.failure", handler));
+      const result = await runCapturedSyntheticProbes(capture, { timeoutMs: 25 });
+      assert.equal(result.results[0].status, "fail");
+      assert.match(result.results[0].error, error);
+    });
+  }
 });
 
 test("synthetic probes keep opt-in registrations guarded", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where synthetic Gateway probes could call the same handler three times, skip handlers registered with positional options, and report success for missing, malformed, or unsuccessful RPC responses.

## Why This Change Was Made

Invoke each logical Gateway method once and collect its first emitted response with a void `respond` callback. Validate that response's JSON wire representation, using `payload` rather than `result` and excluding logging metadata. The first response remains authoritative even if it is invalid; later frames do not overwrite it.

Preserve OpenClaw's plugin return adaptation: without an explicit response, any non-`undefined` return becomes a successful payload, including falsy values. A deferred response remains observable within the existing probe deadline. Handler throws, rejections, timeouts, and cancellation retain the existing probe behavior.

Contract references, personally checked against current source and `v2026.9.3`:

- [Plugin handler adapter and explicit-response authority](https://github.com/openclaw/openclaw/blob/ff612431704ac63f795573b99675ec10510c6d04/src/plugins/registry-registrars-network.ts#L33-L44).
- [Default client first-response handling; final waiting is opt-in](https://github.com/openclaw/openclaw/blob/ff612431704ac63f795573b99675ec10510c6d04/packages/gateway-client/src/pending-request.ts#L159-L184).
- [Response and error schemas](https://github.com/openclaw/openclaw/blob/ff612431704ac63f795573b99675ec10510c6d04/packages/gateway-protocol/src/schema/frames.ts#L177-L202).
- [Stable plugin adapter](https://github.com/openclaw/openclaw/blob/v2026.9.3/src/plugins/registry-registrars-network.ts#L33-L44).

## User Impact

Gateway probes now provide evidence of the initial RPC response plus ordinary handler settlement within the existing deadline. An accepted-only success remains valid. This does not prove asynchronous operation completion, transport delivery, or authorization, and it makes no live Gateway calls.

Public capture helpers, retained runtime/function identity, metadata-only registrars, opt-in gates, report fields, and existing timeout/cancellation bounds remain unchanged. No dependencies, configuration, or release changes.

## Evidence

- Base: `dc2bdb34bd297e068be820c8dda062570b9e3e5a`, including the landed bounded synthetic probe owner.
- Reviewed head: `0a9eb569e11906586107b8baf0ec347204717a52`.
- Before the fix, behavioral regressions reproduced six handler calls instead of two, zero calls with positional options, false-green error/malformed/missing responses, and completion before a deferred callback emitted.
- Focused proof: `node --test test/synthetic-probes.test.js test/capture-api.test.js`, 86/86 passed.
- Full local proof on Node 24.19.0: `npm run check`, 485/485 tests passed, zero failures/skips, package contents passed.
- Syntax checks and `git diff --check` passed. The repository has no configured formatter command.
- Independent P2 review: scoped-clean, no actionable P0-P2 findings. The only subsequent change clarified the changelog's first-emitted-response wording.
- [Exact-head Node 22 CI](https://github.com/openclaw/plugin-inspector/actions/runs/34377651206): passed on Node 22.23.2, 485/485 tests, zero failures/skips, package contents passed.
- [Exact-head CodeQL](https://github.com/openclaw/plugin-inspector/actions/runs/34377648739): both Actions and JavaScript/TypeScript analyses passed.

Maintainer source review and exact-head checks are complete. Squash integration is authorized for reviewed head `0a9eb569e11906586107b8baf0ec347204717a52`. Release publication and downstream release follow-through remain outside this bounded repair.
