### PR TITLE
chore(release): prepare plugin-inspector 0.3.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.25 - 2026-09-09
+
 ### Fixed
 
 - Invoke each synthetic Gateway method once, including registrations with options, and validate its first emitted response's JSON wire representation instead of treating any nonthrowing callback as successful. Preserve explicit response authority, returned-payload fallback, deferred replies within the existing deadline, and accepted-only initial responses.
@@ -12,7 +14,6 @@
 - Bound mock-SDK capture and profile child lifetimes, output, and process sampling; clean owned POSIX descendants through stdio close and keep timeout/cancellation outcomes unsuccessful. Flush complete capture JSON before exiting despite retained plugin timers. Thanks @SebTardif.
 - Profile the default import-loop capture runner directly so its timeout also owns plugin execution. Validate fresh, bounded capture artifacts; RSS/CPU and wall-time measurements now exclude the intermediate CLI wrapper and are not directly comparable with historical profiles.
 - Bound OpenClaw npm metadata and tarball downloads with a deadline through response-body reads, reject oversized responses, and release failed downloads. Resolve `latest` and `beta` through the small npm dist-tags endpoint before fetching exact-version metadata, keeping the 16 MiB metadata limit usable.
-
 - Capture plugins that bind `api.runtime.modelAuth` during registration with credential-free defaults; auth acquisition remains an explicit synthetic failure.
 - Report absent build output and missing entrypoints before SDK alias blockers in cold-import readiness, preserving build-required totals and all remediation evidence.
 - Recognize board widget content kinds, memory prompt preparation, transcript source providers, worker providers, and MCP server connection resolvers as metadata-only synthetic probes without invoking runtime callbacks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/plugin-inspector",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/plugin-inspector",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "private": false,
   "description": "Offline compatibility inspector for OpenClaw plugins.",
   "type": "module",


### PR DESCRIPTION
## What Problem This Solves

Prepares the reviewed plugin-inspector fixes since v0.3.24 for the 0.3.25 release.

## Why This Change Was Made

Updates only package.json, both package-lock.json version fields, and the dated changelog. Runtime code, dependencies, and the tag-triggered trusted-publishing workflow are unchanged by this PR.

## User Impact

The release includes bounded capture, profiling, registration, and synthetic probes; serial service lifecycle probes; CommonJS SDK mock capture; metadata-only registrar coverage; small npm dist-tags resolution; and truthful synthetic Gateway response validation. Existing contributor credit is retained in the release notes.

## Evidence

- Candidate: `c311cee2c73c32d8e917b1bcad7f73d955ba4dc9`, based on merged Gateway repair `3a03b8d22685e04bf19bed37c63ed3c9186ca5dc`.
- `npm run release:local` on Node 24.19.0: 485 tests passed, zero failures or skips; package contents passed with 59 entries.
- Exact-head Node 22.23.2 CI: 485 tests passed and package contents passed in https://github.com/openclaw/plugin-inspector/actions/runs/34378525545. CodeQL passed in https://github.com/openclaw/plugin-inspector/actions/runs/34378523462.
- Fresh P2 review of the candidate against `v0.3.24` (33 changed files): scoped-clean. This PR itself changes only the three release-metadata files.
- Actual 0.3.25 tarball installed into an isolated directory: all 19 public exports loaded, root API detected `registerTool`, and installed CLI help succeeded. All 59 installed package files match the candidate commit byte-for-byte. Tarball SHA-256: `d29d54c51d729f2162473a242e1a0d00e0c5ba75eb5b2b67b2aa2aed40dc6151`.
- Actual Crabpot `plugin-inspector:smoke` on current main `6219f185358ff03219bf2953c6b114ffaee9a78a`: explicit candidate source mode and explicit installed-tarball binary mode each passed 59 fixtures with zero breakages. The generated reports match apart from timestamps.
- Acquisition preserved all 30 gitlink pins. The 27 npm fixtures used exact recorded shim versions with lifecycle scripts disabled, validated archive containment, and registry-derived source metadata. Matrix and Mattermost retained native source-pack mode from the unchanged pinned OpenClaw host `5570c5ffac86acb74979c7314da6f3364781985a`. No fixture config, gitlink, npm pin, or report expectation was changed.
- Additional source/packed compatibility reports against that pinned host match: 59 fixtures, zero fixture breakages, 384 retained findings including nine live/P0 findings. This is not a clean-host or runtime-execution claim. The unchanged `openclaw-target.js` parser misses compat records re-exported by the host's `registry.ts`, reporting zero records; this pre-existing limitation remains visible and is outside this version-only PR.
- One published `0.3.24` compatibility run against those exact same 59 fixtures and pinned host confirms all 384 normalized issues, including all nine P0 findings, are unchanged: zero added, removed, or modified issues; identical target surfaces and zero fixture breakages. The only summary delta is `logCount: 340 -> 341`, from one additional informational `sdk-exports-present` log for Lossless Claw's `openclaw/plugin-sdk/logging-core` import.
- Crabpot source-pin/CLI guards: 5 tests passed. Focused report, cold-import, and synthetic consumers: 20 tests passed without expectation changes. Its scoped source-pin/docs follow-through received a separate clean P2 review.
- Before publication, `release:crabpot` passed the exact candidate source-ref and public-API checks while the package pin intentionally remained `0.3.24`. The completed post-publication checks are recorded below. The checklist itself does not execute smokes.

The source owner has accepted candidate `c311cee2c73c32d8e917b1bcad7f73d955ba4dc9` and tree `0609c24456b8ff146c488f47e01eab2d3c7c637d`, including the three-file version diff, both P2 receipts, exact-head CI, source/packed smokes, and the same-input published baseline. Normal squash merge is authorized without an administrator bypass. The disclosed compat-registry limitation is pre-existing and accepted as non-blocking for this release.

## Release Outcome

- Squash-merged as `2e21b3b48aa06fea30b08202f4c6be13c1f3216a`, with tree `0609c24456b8ff146c488f47e01eab2d3c7c637d` identical to the accepted candidate. Crabpot's source pin and test were repinned to that landed SHA, and the source binding was accepted before tag clearance.
- After explicit owner clearance, annotated `v0.3.25` was pushed once at that exact commit. The existing tag-push Release workflow succeeded, including 485 tests, npm trusted publishing, and GitHub release creation: https://github.com/openclaw/plugin-inspector/actions/runs/34380426028.
- Published release: https://github.com/openclaw/plugin-inspector/releases/tag/v0.3.25. npm version and latest tag are `0.3.25`; registry `gitHead` is the landed SHA. The published tarball has the same SHA-256 and integrity as the reviewed candidate.
- Fresh registry installation with lifecycle scripts disabled passed all 19 public exports, the root API check, installed CLI help, and byte comparison of all 59 package files against the landed commit. `npm audit signatures` verified all eight installed package signatures and two attestations. Inspector provenance binds the package digest to the exact source SHA, `refs/tags/v0.3.25`, `.github/workflows/release.yml`, and Release run `34380426028`.
- Crabpot's scoped follow-through updates its package pin to `0.3.25`. Actual default published-mode smoke, with all BIN/CLI/DIR overrides unset and a fresh npm cache, passed all 59 unchanged fixtures with zero breakages. Published inventory and pinned-host compatibility reports match the accepted source/packed reports apart from timestamps, retaining the same 384 compatibility findings. No fixture or report expectation changed.
- Strict `release:crabpot --expected-ref 2e21b3b48aa06fea30b08202f4c6be13c1f3216a --expected-version 0.3.25 --published` passed, as did all five final pin/CLI tests. Crabpot follow-through remains a separate PR requiring its own merge clearance.
